### PR TITLE
Utilize Unicorn 3.1 explicit exclude children grammar for clarity

### DIFF
--- a/src/Foundation/Serialization/code/App_Config/Include/Foundation/Foundation.Serialization.config
+++ b/src/Foundation/Serialization/code/App_Config/Include/Foundation/Foundation.Serialization.config
@@ -37,67 +37,67 @@
 							NOTE: the "name" attribute controls the folder name the items will go into (for SFS). If unspecified, the last path segment is used. Names must be unique across the configuration.
 						-->
             <include name="Foundation.Serialization.Templates.Feature" database="master" path="/sitecore/templates/Feature">
-              <exclude path="/sitecore/templates/Feature/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Templates.Foundation" database="master" path="/sitecore/templates/Foundation">
-              <exclude path="/sitecore/templates/Foundation/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Templates.Project" database="master" path="/sitecore/templates/Project">
-              <exclude path="/sitecore/templates/Project/" />
+              <exclude children="true" />
             </include>
 
             <include name="Foundation.Serialization.Branches.Foundation" database="master" path="/sitecore/templates/branches/Foundation">
-              <exclude path="/sitecore/templates/branches/Foundation/" />
+              <exclude children="true" />
             </include>
 
             <include name="Foundation.Serialization.Renderings.Feature" database="master" path="/sitecore/layout/renderings/Feature">
-              <exclude path="/sitecore/layout/renderings/Feature/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Renderings.Foundation" database="master" path="/sitecore/layout/renderings/Foundation">
-              <exclude path="/sitecore/layout/renderings/Foundation/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Renderings.Project" database="master" path="/sitecore/layout/renderings/Project">
-              <exclude path="/sitecore/layout/renderings/Project/" />
+              <exclude children="true" />
             </include>
 
             <include name="Foundation.Serialization.Layouts.Feature" database="master" path="/sitecore/layout/layouts/Feature">
-              <exclude path="/sitecore/layout/layouts/Feature/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Layouts.Foundation" database="master" path="/sitecore/layout/layouts/Foundation">
-              <exclude path="/sitecore/layout/layouts/Foundation/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Layouts.Project" database="master" path="/sitecore/layout/layouts/Project">
-              <exclude path="/sitecore/layout/layouts/Project/" />
+              <exclude children="true" />
             </include>
 
             <include name="Foundation.Serialization.PlaceholderSettings.Feature" database="master" path="/sitecore/layout/placeholder settings/Feature">
-              <exclude path="/sitecore/layout/placeholder settings/Feature/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.PlaceholderSettings.Foundation" database="master" path="/sitecore/layout/placeholder settings/Foundation">
-              <exclude path="/sitecore/layout/placeholder settings/Foundation/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.PlaceholderSettings.Project" database="master" path="/sitecore/layout/placeholder settings/Project">
-              <exclude path="/sitecore/layout/placeholder settings/Project/" />
+              <exclude children="true" />
             </include>
 
             <include name="Foundation.Serialization.Models.Feature" database="master" path="/sitecore/layout/models/Feature">
-              <exclude path="/sitecore/layout/models/Feature/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Models.Foundation" database="master" path="/sitecore/layout/models/Foundation">
-              <exclude path="/sitecore/layout/models/Foundation/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Serialization.Models.Project" database="master" path="/sitecore/layout/models/Project">
-              <exclude path="/sitecore/layout/models/Project/" />
+              <exclude children="true" />
             </include>
 
             <include name="Foundation.Core.Templates.Feature" database="core" path="/sitecore/templates/Feature">
-              <exclude path="/sitecore/templates/Feature/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Core.Templates.Foundation" database="core" path="/sitecore/templates/Foundation">
-              <exclude path="/sitecore/templates/Foundation/" />
+              <exclude children="true" />
             </include>
             <include name="Foundation.Core.Templates.Project" database="core" path="/sitecore/templates/Project">
-              <exclude path="/sitecore/templates/Project/" />
+              <exclude children="true" />
             </include>
           </predicate>
         </configuration>


### PR DESCRIPTION
3.1 has improved config grammar to exclude children that is less implicit than a trailing slash and more obvious to a reader what the intention is.

This PR switches to using that.