### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,17 @@ gulp.task("01-Copy-Sitecore-Lib", function () {
   var files = config.sitecoreLibraries + "/**/*";
   gulp.src(files)
     .pipe(gulp.dest("./lib/Sitecore"));
+
+  var root = "./src";
+  var projects = root + "/**/code/bin";
+  gulp.src(projects, { base: root })
+    .pipe(foreach(function (stream, file) {
+      console.log("copying to " + file.path);
+      gulp.src(files)
+        .pipe(gulp.dest(file.path));
+      return stream;
+    }));
+
 });
 
 gulp.task("02-Publish-All-Projects", function (callback) {


### PR DESCRIPTION
"01-Copy-Sitecore-Lib" function was not working probably. It wasn't copying Sitecore DLLs from the root site into each project. I edited the function's code, tested it and it is working perfectly fine now.