### PR TITLE
Review fixes

### DIFF
--- a/Habitat.sln
+++ b/Habitat.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Foundation.SitecoreExtensions", "src\foundation\SitecoreExtensions\code\Sitecore.Foundation.SitecoreExtensions.csproj", "{B535703F-8D07-4F23-A533-2974BB4CC7B1}"
 EndProject
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configurat
 		package.xml = package.xml
 		publishsettings.targets = publishsettings.targets
 		README.md = README.md
+		WebEssentials2015-Settings.json = WebEssentials2015-Settings.json
 		src\Project\Habitat\code\App_Config\Include\Project\z.Habitat.DevSettings.config = src\Project\Habitat\code\App_Config\Include\Project\z.Habitat.DevSettings.config
 	EndProjectSection
 EndProject
@@ -155,11 +156,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Foundation.Alerts", "src\Foundation\Alerts\code\Sitecore.Foundation.Alerts.csproj", "{5CF5FA06-AB27-4DF5-A471-ED57EF3E4AE9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Foundation.Alerts.Tests", "src\Foundation\Alerts\tests\Sitecore.Foundation.Alerts.Tests.csproj", "{EC2C5218-7C4E-4010-820B-8F2593E77AE3}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1B32FB80-BED9-4746-9362-CDB810C20896}"
-	ProjectSection(SolutionItems) = preProject
-		WebEssentials2015-Settings.json = WebEssentials2015-Settings.json
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Feature/PageContent/code/Views/PageContent/PageTitle.cshtml
+++ b/src/Feature/PageContent/code/Views/PageContent/PageTitle.cshtml
@@ -16,8 +16,8 @@
   </h1>
   @if (Model.Item.Fields[Templates.HasPageContent.Fields.Summary].HasValue || Sitecore.Context.PageMode.IsExperienceEditor)
   {
-    <p class="lead">
+    <div class="lead">
       @Html.Sitecore().Field(Templates.HasPageContent.Fields.Summary.ToString(), Model.Item)
-    </p>
+    </div>
   }
 </header>

--- a/src/Foundation/SitecoreExtensions/Tests/Renderings/QueryableDatasourceRenderingModelTests.cs
+++ b/src/Foundation/SitecoreExtensions/Tests/Renderings/QueryableDatasourceRenderingModelTests.cs
@@ -6,11 +6,9 @@
   using FluentAssertions;
   using NSubstitute;
   using NSubstitute.Extensions;
-  using Ploeh.AutoFixture.Xunit2;
   using Sitecore.Abstractions;
   using Sitecore.ContentSearch;
   using Sitecore.ContentSearch.Linq.Common;
-  using Sitecore.ContentSearch.Pipelines.GetContextIndex;
   using Sitecore.ContentSearch.SearchTypes;
   using Sitecore.ContentSearch.Utilities;
   using Sitecore.Data;
@@ -31,15 +29,17 @@
 
   public class QueryableDatasourceRenderingModelTests
   {
-
     public class FakeDatasourceResolverPipeline : IPipelineProcessor
     {
       public Item Item { get; set; }
+
       public void Process(PipelineArgs args)
       {
         var castedArgs = args as GetRenderingDatasourceArgs;
         if (castedArgs != null)
+        {
           castedArgs.Prototype = Item;
+        }
       }
     }
 
@@ -52,10 +52,16 @@
       var results = GetResults(contentItems).ToArray();
       results.First().Language = "noncontext";
       renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
 
       InitIndexes(index, searchProvider, results.AsQueryable());
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items;
@@ -63,7 +69,6 @@
       //assert
       items.Count().Should().Be(contentItems.Length - 1);
       index.CreateSearchContext().ReceivedWithAnyArgs(1);
-
     }
 
 
@@ -75,18 +80,23 @@
       var results = GetResults(contentItems).ToArray();
       results.First().IsLatestVersion = false;
       renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
 
       InitIndexes(index, searchProvider, results.AsQueryable());
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items;
 
       //assert
-      items.Count().Should().Be(contentItems.Length-1);
+      items.Count().Should().Be(contentItems.Length - 1);
       index.CreateSearchContext().ReceivedWithAnyArgs(1);
-
     }
 
 
@@ -97,10 +107,16 @@
       //arrange
       var results = GetResults(contentItems);
       renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
 
       InitIndexes(index, searchProvider, results);
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items;
@@ -108,9 +124,7 @@
       //assert
       items.Count().Should().Be(contentItems.Length);
       index.CreateSearchContext().ReceivedWithAnyArgs(1);
-
     }
-
 
 
     [Theory]
@@ -122,12 +136,21 @@
       var dbItem = new DbItem(Sitecore.Constants.StandardValuesItemName, id);
       db.Add(dbItem);
 
-      renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>().Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+      renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>().Returns(new QueryableDatasourceRenderingSettings
+      {
+        SearchResultsLimit = 10
+      });
 
-      var results = GetResults(new List<DbItem>() { dbItem });
+      var results = GetResults(new List<DbItem>
+      {
+        dbItem
+      });
 
       InitIndexes(index, searchProvider, results);
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items.ToArray();
@@ -148,7 +171,6 @@
       {
         DataSource = "ds",
         RenderingItem = new RenderingItem(renderingItem)
-        
       };
       ContextService.Get().Push(new PageContext());
       PageContext.Current.Item = renderingItem;
@@ -165,7 +187,7 @@
 
     [Theory]
     [AutoDbData]
-    public void Items_ItemTemplateSet_FiltersByTemplateId(Db db, [Content] DbTemplate templateItem,  [Content] DbItem[] contentItems, ISearchIndex index, [ReplaceSearchProvider] SearchProvider searchProvider, string indexName, [Content] Item renderingItem, IRenderingPropertiesRepository renderingPropertiesRepository)
+    public void Items_ItemTemplateSet_FiltersByTemplateId(Db db, [Content] DbTemplate templateItem, [Content] DbItem[] contentItems, ISearchIndex index, [ReplaceSearchProvider] SearchProvider searchProvider, string indexName, [Content] Item renderingItem, IRenderingPropertiesRepository renderingPropertiesRepository)
     {
       //arrange
       var dbItem = new DbItem("templated", ID.NewID, templateItem.ID);
@@ -174,13 +196,20 @@
       dbItems.Add(dbItem);
       var results = GetResults(dbItems);
       renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
 
-      InitIndexes(index, searchProvider,  results);
+      InitIndexes(index, searchProvider, results);
 
-      
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) {Rendering = new Rendering() {DataSource = "notEmpty"} };
-      renderingModel.DatasourceTemplate = db.GetItem(templateItem.ID);
+
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        Rendering = new Rendering(),
+        DatasourceString = "notEmpty",
+        DatasourceTemplate = db.GetItem(templateItem.ID)
+      };
 
       //act
       var items = renderingModel.Items;
@@ -193,20 +222,26 @@
 
     [Theory]
     [AutoDbData]
-    public void Items_IndexHaveNonexistentItems_ReturnsExistentItems([Content] DbItem[] contentItems, DbItem brokenItem, 
-      List<DbItem> indexedItems, ISearchIndex index, string indexName, 
+    public void Items_IndexHaveNonexistentItems_ReturnsExistentItems([Content] DbItem[] contentItems, DbItem brokenItem,
+      List<DbItem> indexedItems, ISearchIndex index, string indexName,
       [ReplaceSearchProvider] SearchProvider searchProvider, [Content] Item renderingItem, IRenderingPropertiesRepository renderingPropertiesRepository)
     {
       //arrange
       indexedItems.AddRange(contentItems);
       indexedItems.Add(brokenItem);
       renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
 
       var results = GetResults(indexedItems);
 
       InitIndexes(index, searchProvider, results);
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items.ToArray();
@@ -219,21 +254,30 @@
 
     [Theory]
     [AutoDbData]
-    public void Items_StandardValuesExists_IgnoresItemsUnderTemplates(Db db, ISearchIndex index, 
+    public void Items_StandardValuesExists_IgnoresItemsUnderTemplates(Db db, ISearchIndex index,
       [ReplaceSearchProvider] SearchProvider searchProvider, [Content] Item renderingItem, IRenderingPropertiesRepository renderingPropertiesRepository)
     {
       //arrange
       var templateID = ID.NewID;
       db.Add(new DbTemplate("Sample", templateID));
-      var stdValues = db.GetItem("/sitecore/templates/Sample").Add( Sitecore.Constants.StandardValuesItemName, new TemplateID(templateID));
-      
-      renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+      var stdValues = db.GetItem("/sitecore/templates/Sample").Add(Sitecore.Constants.StandardValuesItemName, new TemplateID(templateID));
 
-      var results = GetResults(new List<DbItem>() { new DbItem(Sitecore.Constants.StandardValuesItemName, stdValues.ID) });
+      renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
+
+      var results = GetResults(new List<DbItem>
+      {
+        new DbItem(Sitecore.Constants.StandardValuesItemName, stdValues.ID)
+      });
 
       InitIndexes(index, searchProvider, results);
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items.ToArray();
@@ -244,17 +288,22 @@
     }
 
 
-
     [Theory]
     [AutoDbData]
-    public void Items_IndexEmpty_ReturnsEmptyCollection([ResolvePipeline("getRenderingDatasource")] EmptyPipeline processor, List<DbItem> indexedItems,  ISearchIndex index, string indexName, [ReplaceSearchProvider] SearchProvider searchProvider, [Content] Item renderingItem, IRenderingPropertiesRepository renderingPropertiesRepository)
+    public void Items_IndexEmpty_ReturnsEmptyCollection([ResolvePipeline("getRenderingDatasource")] EmptyPipeline processor, List<DbItem> indexedItems, ISearchIndex index, string indexName, [ReplaceSearchProvider] SearchProvider searchProvider, [Content] Item renderingItem, IRenderingPropertiesRepository renderingPropertiesRepository)
     {
       //arrange
-      InitIndexes(index, searchProvider,  new List<SearchResultItem>().AsQueryable());
+      InitIndexes(index, searchProvider, new List<SearchResultItem>().AsQueryable());
       renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>()
-        .Returns(new QueryableDatasourceRenderingSettings() { SearchResultsLimit = 10 });
+        .Returns(new QueryableDatasourceRenderingSettings
+        {
+          SearchResultsLimit = 10
+        });
 
-      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository) { Rendering = new Rendering() { DataSource = "notEmpty" } };
+      var renderingModel = new QueryableDatasourceRenderingModel(renderingPropertiesRepository)
+      {
+        DatasourceString = "notEmpty"
+      };
 
       //act
       var items = renderingModel.Items;
@@ -266,12 +315,12 @@
 
     [Theory]
     [AutoDbData]
-    public void Items_EmptyDatasource_ReturnsEmptyCollection([ResolvePipeline("getRenderingDatasource")] EmptyPipeline processor, List<DbItem> indexedItems,SearchProvider searchProvider, ISearchIndex index, string indexName, [Content] Item renderingItem)
+    public void Items_EmptyDatasource_ReturnsEmptyCollection([ResolvePipeline("getRenderingDatasource")] EmptyPipeline processor, List<DbItem> indexedItems, SearchProvider searchProvider, ISearchIndex index, string indexName, [Content] Item renderingItem)
     {
       //arrange
 
       InitIndexes(index, searchProvider, new List<SearchResultItem>().AsQueryable());
-      var renderingModel = new QueryableDatasourceRenderingModel() { Rendering = new Rendering()};
+      var renderingModel = new QueryableDatasourceRenderingModel();
 
       //act
       var items = renderingModel.Items;
@@ -279,7 +328,48 @@
       //assert
       items.Count().Should().Be(0);
       index.CreateSearchContext().DidNotReceiveWithAnyArgs();
- 
+    }
+
+
+    [Theory]
+    [AutoDbData]
+    public void DatasourceString_EmptyDatasource_ContextItemAsLocationRoot([ResolvePipeline("getRenderingDatasource")] EmptyPipeline processor, [Content] Item renderingItem)
+    {
+      //arrange
+      ContextService.Get().Push(new PageContext());
+      PageContext.Current.Item = renderingItem;
+      var renderingModel = new QueryableDatasourceRenderingModel();
+
+      //act
+      renderingModel.Initialize(new Rendering
+      {
+        DataSource = string.Empty,
+        RenderingItem = new RenderingItem(renderingItem)
+      });
+
+      //assert
+      renderingModel.DatasourceString.Should().Be("+location:" + PageContext.Current.Item.ID);
+    }
+
+    [Theory]
+    [AutoDbData]
+    public void DatasourceString_IdAsDatasource_IDSetAsLocationRoot([ResolvePipeline("getRenderingDatasource")] EmptyPipeline processor, [Content] Item renderingItem)
+    {
+      //arrange
+      ContextService.Get().Push(new PageContext());
+      PageContext.Current.Item = renderingItem;
+      var renderingModel = new QueryableDatasourceRenderingModel();
+      var dataSource = ID.NewID.ToString();
+
+      //act
+      renderingModel.Initialize(new Rendering
+      {
+        DataSource = dataSource,
+        RenderingItem = new RenderingItem(renderingItem)
+      });
+
+      //assert
+      renderingModel.DatasourceString.Should().Be("+location:" + dataSource);
     }
 
 
@@ -290,20 +380,26 @@
       foreach (var item in contentItems)
       {
         var searchResultItem = Substitute.For<SearchResult>();
-        searchResultItem.Templates = new List<string> { IdHelper.NormalizeGuid(item.TemplateID) };
+        searchResultItem.Templates = new List<string>
+        {
+          IdHelper.NormalizeGuid(item.TemplateID)
+        };
         searchResultItem.IsLatestVersion = true;
         searchResultItem.Language = Context.Language.Name;
         searchResultItem.Name.Returns(item.Name);
 
         var dbItem = Context.Database.GetItem(item.ID);
         searchResultItem.GetItem().Returns(dbItem);
-        searchResultItem.Paths.Returns(dbItem?.Paths.LongID.Split(new [] {'/'},StringSplitOptions.RemoveEmptyEntries).Select(x => new ID(x)).ToArray()??new ID[0]);
+        searchResultItem.Paths.Returns(dbItem?.Paths.LongID.Split(new[]
+        {
+          '/'
+        }, StringSplitOptions.RemoveEmptyEntries).Select(x => new ID(x)).ToArray() ?? new ID[0]);
         list.Add(searchResultItem);
       }
       return list.AsQueryable();
     }
 
-    private static void InitIndexes(ISearchIndex index, SearchProvider searchProvider,  IQueryable<SearchResultItem> results)
+    private static void InitIndexes(ISearchIndex index, SearchProvider searchProvider, IQueryable<SearchResultItem> results)
     {
       ContentSearchManager.SearchConfiguration.Indexes.Clear();
       searchProvider?.GetContextIndexName(Arg.Any<IIndexable>(), Arg.Any<ICorePipeline>()).Returns("CustomIndexName");

--- a/src/Foundation/SitecoreExtensions/code/Rendering/QueryableDatasourceRenderingModel.cs
+++ b/src/Foundation/SitecoreExtensions/code/Rendering/QueryableDatasourceRenderingModel.cs
@@ -16,6 +16,7 @@
   public class QueryableDatasourceRenderingModel : RenderingModel
   {
     private readonly IRenderingPropertiesRepository renderingPropertiesRepository;
+    private const int DefaultMaxResults = 10;
 
     public QueryableDatasourceRenderingSettings Settings => renderingPropertiesRepository.Get<QueryableDatasourceRenderingSettings>();
 
@@ -40,7 +41,7 @@
     {
       get
       {
-        var dataSource = Rendering.DataSource;
+        var dataSource = ParseRenderingDataSource();
         if (string.IsNullOrEmpty(dataSource))
         {
           return Enumerable.Empty<Item>();
@@ -60,12 +61,28 @@
             .Where(x => x.IsLatestVersion)
             .Where(x => !x.Paths.Contains(ItemIDs.TemplateRoot))
             .Where(x => !x.Name.Equals(Sitecore.Constants.StandardValuesItemName, StringComparison.InvariantCultureIgnoreCase))
-            .Take(Settings.SearchResultsLimit)
+            .Take(MaxResults)
             .Select(current => current != null ? current.GetItem() : null)
             .ToArray()
             .Where(item => item != null);
         }
       }
+    }
+
+    private int MaxResults => Settings.SearchResultsLimit > 0 ? Settings.SearchResultsLimit : DefaultMaxResults;
+
+    private string ParseRenderingDataSource()
+    {
+      var dataSource = Rendering.DataSource;
+      if (string.IsNullOrWhiteSpace(dataSource))
+      {
+        dataSource = "+location:" + Rendering.Item.ID;
+      }
+      if (MainUtil.IsID(dataSource))
+      {
+        dataSource = "+location:" + dataSource;
+      }
+      return dataSource;
     }
 
 

--- a/src/Foundation/SitecoreExtensions/code/Rendering/QueryableDatasourceRenderingModel.cs
+++ b/src/Foundation/SitecoreExtensions/code/Rendering/QueryableDatasourceRenderingModel.cs
@@ -35,21 +35,21 @@
     {
       base.Initialize(rendering);
       ResolveDatasourceTemplate(rendering);
+      ParseRenderingDataSource(rendering);
     }
 
     public virtual IEnumerable<Item> Items
     {
       get
       {
-        var dataSource = ParseRenderingDataSource();
-        if (string.IsNullOrEmpty(dataSource))
+        if (string.IsNullOrEmpty(DatasourceString))
         {
           return Enumerable.Empty<Item>();
         }
 
         using (var providerSearchContext = ContentSearchManager.GetIndex((SitecoreIndexableItem)Context.Item).CreateSearchContext())
         {
-          var items = LinqHelper.CreateQuery<SearchResultItem>(providerSearchContext, SearchStringModel.ParseDatasourceString(dataSource));
+          var items = LinqHelper.CreateQuery<SearchResultItem>(providerSearchContext, SearchStringModel.ParseDatasourceString(DatasourceString));
           var searchResultItems = items.Cast<SearchResult>();
           if (DatasourceTemplate != null)
           {
@@ -71,9 +71,9 @@
 
     private int MaxResults => Settings.SearchResultsLimit > 0 ? Settings.SearchResultsLimit : DefaultMaxResults;
 
-    private string ParseRenderingDataSource()
+    private void ParseRenderingDataSource(Rendering rendering)
     {
-      var dataSource = Rendering.DataSource;
+      var dataSource = rendering.DataSource;
       if (string.IsNullOrWhiteSpace(dataSource))
       {
         dataSource = "+location:" + Rendering.Item.ID;
@@ -82,8 +82,10 @@
       {
         dataSource = "+location:" + dataSource;
       }
-      return dataSource;
+      this.DatasourceString =  dataSource;
     }
+
+    public string DatasourceString { get; set; }
 
 
     private void ResolveDatasourceTemplate(Rendering rendering)

--- a/src/Project/Habitat/serialization/Habitat.Website.Templates/Habitat/Page Types/Employees folder/__Standard Values.yml
+++ b/src/Project/Habitat/serialization/Habitat.Website.Templates/Habitat/Page Types/Employees folder/__Standard Values.yml
@@ -13,7 +13,7 @@ SharedFields:
   Hint: __Renderings
   Type: layout
   Value: |
-    <r>
+    <r xmlns:xsd="http://www.w3.org/2001/XMLSchema">
       <d id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}" l="{ED043C36-CD48-4EDF-A288-EC404EE1CD42}">
         <r id="{E7AE3F87-CF66-40F2-A9F5-33ECF08BC777}" ph="head" uid="{E6CA18D8-321D-4105-9C38-0622E94BE400}" />
         <r id="{3389CAFC-000C-41E5-921C-92821B3DB7B5}" ph="head" uid="{EF51B238-7CE2-4E39-AB87-D05424735160}" />
@@ -33,7 +33,7 @@ SharedFields:
         <r id="{45B8E1D9-D522-49E0-B9B7-04C965CC7089}" ph="page-header" uid="{A07B671F-1436-4861-9202-072F4B7265FD}" />
         <r id="{D201A487-5099-48A1-8189-55944F70C6CB}" par="UseStaticPlaceholderNames=1" ph="page-layout" uid="{66422117-69C1-4B62-9323-482F16C4F244}" />
         <r id="{0AD8EC59-33EC-4103-AAD4-F3A49BFDB92C}" par="UseStaticPlaceholderNames=1" ph="/page-layout/section" uid="{DF9DD435-0094-4FFB-BFCC-1F36BB682785}" />
-        <r ds="." id="{DC19892A-B345-4EFE-AAA2-6E27A801A733}" ph="/page-layout/section/col-huge" uid="{7E360D99-6210-4C19-86A8-CB276EE7E478}" />
+        <r ds="" id="{DC19892A-B345-4EFE-AAA2-6E27A801A733}" par="" ph="/page-layout/section/col-huge" uid="{7E360D99-6210-4C19-86A8-CB276EE7E478}" />
         <r id="{299FD8EA-2CFD-4A69-9CA4-7EA24CD34A46}" ph="footer" uid="{E2040FB7-4151-456D-9315-5973E4EB4D9D}" />
         <r id="{98D6BC34-0185-42A0-B53B-CEB7B17008B6}" par="UseStaticPlaceholderNames=1" ph="/footer/section" uid="{025588CB-DFC0-4B02-8223-0015C525AE52}" />
         <r ds="{FB1E4810-6D89-4F1E-A47B-70478FE32DA7}" id="{F366FBA9-EF26-4007-988A-63CB64649C46}" ph="/footer/section/col-narrow-1" uid="{0E0C6DCA-1A29-4975-84D7-E99498A64A72}" />


### PR DESCRIPTION
Fixed the QueryableDatasourceRenderingModel to default to search under the current items and a default of max 10 items
Cleanup: Moved WebEssentials file to Configuration folder
Changed header lead to div to cater for p tags from the RTE