### PR TITLE
Fixed incorrect include

### DIFF
--- a/src/Feature/faq/code/Sitecore.Feature.FAQ.csproj
+++ b/src/Feature/faq/code/Sitecore.Feature.FAQ.csproj
@@ -101,9 +101,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
-    <Content Include="App_Config\include\FAQ\Feature.FAQ.Serialization.config" />
     <Content Include="Views\web.config" />
     <Content Include="Views\FAQ\FaqAccordion.cshtml" />
+    <Content Include="App_Config\include\Feature\Feature.FAQ.Serialization.config" />
     <None Include="Properties\PublishProfiles\Local.pubxml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>


### PR DESCRIPTION
### Description
**02-Publish-All-Projects** task reports issues during build of FAQ feature project:

```
[12:19:28] Building project: src\Feature\faq\code\Sitecore.Feature.FAQ.csproj
[12:19:28] Using automatic maxcpucount
[12:19:28] Building project: 1 item
[12:19:29] { [Error: Command failed: ] killed: false, code: 1, signal: null }
[12:19:29] Build failed!
[12:19:29] Finished 'Publish-Feature-Projects' after 1.22 s
[12:19:29] Starting 'Publish-Project-Projects'...
```


MS Build Error message
```
C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v14.0\Web\Microsoft.Web.Publishing.targets(2998,5): error
\Feature.FAQ.Serialization.config failed. Could not find a part of the path 'App_Config\include\FAQ\Feature.FAQ
```

## Solution
Fixed include line according to file system structure.