### PR TITLE
Fix hardcoded LicenseFile path (#156)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ artifacts/
 *.userprefs
 *DS_Store
 *.sln.ide
+lib/license.xml
 lib/Sitecore/*
 !lib/Sitecore/readme.MD
 lib/System/*

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,3 @@
+# Required Files
+
+Put the `license.xml` file into this folder.

--- a/src/Feature/Accounts/Tests/Sitecore.Feature.Accounts.Tests.csproj
+++ b/src/Feature/Accounts/Tests/Sitecore.Feature.Accounts.Tests.csproj
@@ -213,6 +213,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Accounts/Tests/app.config
+++ b/src/Feature/Accounts/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
       <setting name="MailServer" value="localhost" />
     </settings>
   </sitecore>

--- a/src/Feature/Demo/tests/Sitecore.Feature.Demo.Tests.csproj
+++ b/src/Feature/Demo/tests/Sitecore.Feature.Demo.Tests.csproj
@@ -170,7 +170,12 @@
       <Name>Sitecore.Feature.Demo</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Demo/tests/app.config
+++ b/src/Feature/Demo/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
     <outcome>
       <outcomeManager type="Sitecore.Analytics.Outcome.OutcomeManager, Sitecore.Analytics.Outcome" singleInstance="true">

--- a/src/Feature/Language/Tests/Sitecore.Feature.Language.Tests.csproj
+++ b/src/Feature/Language/Tests/Sitecore.Feature.Language.Tests.csproj
@@ -128,6 +128,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Language/Tests/app.config
+++ b/src/Feature/Language/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Maps/tests/Sitecore.Feature.Maps.Tests.csproj
+++ b/src/Feature/Maps/tests/Sitecore.Feature.Maps.Tests.csproj
@@ -160,6 +160,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Maps/tests/app.config
+++ b/src/Feature/Maps/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Media/Tests/Sitecore.Feature.Media.Tests.csproj
+++ b/src/Feature/Media/Tests/Sitecore.Feature.Media.Tests.csproj
@@ -121,7 +121,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Media/Tests/app.config
+++ b/src/Feature/Media/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Metadata/Tests/Sitecore.Feature.Metadata.Tests.csproj
+++ b/src/Feature/Metadata/Tests/Sitecore.Feature.Metadata.Tests.csproj
@@ -124,6 +124,12 @@
       <Name>Sitecore.Feature.Metadata</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Metadata/Tests/app.config
+++ b/src/Feature/Metadata/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Multisite/tests/App.config
+++ b/src/Feature/Multisite/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Multisite/tests/Sitecore.Feature.Multisite.Tests.csproj
+++ b/src/Feature/Multisite/tests/Sitecore.Feature.Multisite.Tests.csproj
@@ -130,6 +130,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Feature/News/Tests/Sitecore.Feature.News.Tests.csproj
+++ b/src/Feature/News/Tests/Sitecore.Feature.News.Tests.csproj
@@ -152,6 +152,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/News/Tests/app.config
+++ b/src/Feature/News/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Person/tests/Sitecore.Feature.Person.Tests.csproj
+++ b/src/Feature/Person/tests/Sitecore.Feature.Person.Tests.csproj
@@ -169,6 +169,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Person/tests/app.config
+++ b/src/Feature/Person/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Feature/Search/Tests/Sitecore.Feature.Search.Tests.csproj
+++ b/src/Feature/Search/Tests/Sitecore.Feature.Search.Tests.csproj
@@ -182,6 +182,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Search/Tests/app.config
+++ b/src/Feature/Search/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Alerts/tests/Sitecore.Foundation.Alerts.Tests.csproj
+++ b/src/Foundation/Alerts/tests/Sitecore.Foundation.Alerts.Tests.csproj
@@ -161,6 +161,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Alerts/tests/app.config
+++ b/src/Foundation/Alerts/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Forms/tests/App.config
+++ b/src/Foundation/Forms/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
+++ b/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
@@ -143,6 +143,12 @@
   <ItemGroup>
     <Folder Include="ActionEditors\" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Indexing/Tests/Sitecore.Foundation.Indexing.Tests.csproj
+++ b/src/Foundation/Indexing/Tests/Sitecore.Foundation.Indexing.Tests.csproj
@@ -126,6 +126,12 @@
       <Name>Sitecore.Foundation.Indexing</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Indexing/Tests/app.config
+++ b/src/Foundation/Indexing/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Installer/tests/Sitecore.Foundation.Installer.Tests.csproj
+++ b/src/Foundation/Installer/tests/Sitecore.Foundation.Installer.Tests.csproj
@@ -139,6 +139,12 @@
       <Name>Sitecore.Foundation.Installer</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Installer/tests/app.config
+++ b/src/Foundation/Installer/tests/app.config
@@ -16,7 +16,7 @@
   </connectionStrings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
       <setting name="Xdb.Enabled" value="true" />
     </settings>
     <factories>

--- a/src/Foundation/Multisite/tests/App.config
+++ b/src/Foundation/Multisite/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Multisite/tests/Sitecore.Foundation.Multisite.Tests.csproj
+++ b/src/Foundation/Multisite/tests/Sitecore.Foundation.Multisite.Tests.csproj
@@ -124,7 +124,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Foundation/SitecoreExtensions/Tests/Sitecore.Foundation.SitecoreExtensions.Tests.csproj
+++ b/src/Foundation/SitecoreExtensions/Tests/Sitecore.Foundation.SitecoreExtensions.Tests.csproj
@@ -208,7 +208,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/SitecoreExtensions/Tests/app.config
+++ b/src/Foundation/SitecoreExtensions/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Testing/tests/app.config
+++ b/src/Foundation/Testing/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Theming/tests/App.config
+++ b/src/Foundation/Theming/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Theming/tests/Sitecore.Foundation.Theming.Tests.csproj
+++ b/src/Foundation/Theming/tests/Sitecore.Foundation.Theming.Tests.csproj
@@ -115,6 +115,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\lib\license.xml">
+      <Link>license.xml</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Addresses issue #156 in the following way:
1. The `license.xml` file is put into the `<root>\lib` folder
2. Each of the test projects adds a *link* to the license file configuring the `Copy to Output Directory` property as `Copy if Newer`

This approach works fine with VS Test Explorer and NCrunch. Otherwise one would need to configure NCrunch [manually](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/wiki/Configuration#configuring-ncrunch) for each of the 45+ test projects.