### PR TITLE
ApplyTransform tweak to handle multiple transforms with in project

### DIFF
--- a/applytransform.targets
+++ b/applytransform.targets
@@ -2,21 +2,18 @@
   <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(MSBuildToolsVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
   <Target Name="ApplyTransform">
     <ItemGroup>
-      <Transforms Include="$(ProjectDir)\**\*.transform" Exclude="$(ProjectDir)\obj\**" />
-      
-      <ConfigsToTransform Include="@(Transforms->Replace('.transform','')->Replace('$(ProjectDir)',''))" Condition="Exists(@(Transforms))">
-        <TransformPath>%(Transforms.Identity)</TransformPath>
+      <Transform Include="$(TransformFile)" />
+
+      <ConfigsToTransform Include="$(FileToTransform)" Condition="Exists(@(Transform))">
+        <TransformPath>%(Transform.Identity)</TransformPath>
       </ConfigsToTransform>
     </ItemGroup>
-    <Message Text="@(ConfigsToTransform)"     ></Message>
-    <Message Text="@(Transforms)"     ></Message>
+    <Message Text="@(ConfigsToTransform)"></Message>
+    <Message Text="@(Transform)"></Message>
 
-    <TransformXml Source="$(WebConfigToTransform)\%(ConfigsToTransform.Identity)" 
+    <TransformXml Source="$(WebConfigToTransform)\%(ConfigsToTransform.Identity)"
                   Transform="%(ConfigsToTransform.TransformPath)"
-                  Destination="$(WebConfigToTransform)\%(ConfigsToTransform.Identity)" 
-                  Condition="Exists(@(Transforms))"/>  
-  
-  
+                  Destination="$(WebConfigToTransform)\%(ConfigsToTransform.Identity)"
+                  Condition="Exists(@(Transform))"/>
   </Target>
-
 </Project>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,11 +54,12 @@ gulp.task("03-Publish-All-Projects", function (callback) {
 });
 
 gulp.task("04-Apply-Xml-Transform", function () {
-  var layerPathFilters = ["./src/Foundation/**/code/*.csproj", "./src/Feature/**/code/*.csproj", "./src/Project/**/code/*.csproj"];
+  var layerPathFilters = ["./src/**/*.transform", "!.src/**/obj/**/App_Config", "!.src/**/bin/**/App_Config"];
   return gulp.src(layerPathFilters)
     .pipe(foreach(function (stream, file) {
+      var fileToTransform = file.path.replace(/.+code\\(.+)\.transform/, "$1");
       return gulp.src("./applytransform.targets")
-        .pipe(debug({ title: "Applying transform project:" }))
+        .pipe(debug({ title: "Applying congiuration transform: " + file.path }))
         .pipe(msbuild({
           targets: ["ApplyTransform"],
           configuration: config.buildConfiguration,
@@ -68,7 +69,8 @@ gulp.task("04-Apply-Xml-Transform", function () {
           toolsVersion: 14.0,
           properties: {
             WebConfigToTransform: config.websiteRoot,
-            ProjectDir: path.dirname(file.path)
+            TransformFile: file.path,
+            FileToTransform: fileToTransform
           }
         }));
     }));


### PR DESCRIPTION
Now there can be more than one transformation in each project and process takes much less time

Previous solution was causing an error if there was more than one transformation in any project.
Also since transformation process is only triggered if there is transformation file, it takes much less time than running it for each project regardless. 