### PR TITLE
Use relative license file path

### DIFF
--- a/Habitat.v2.ncrunchsolution
+++ b/Habitat.v2.ncrunchsolution
@@ -1,0 +1,15 @@
+﻿<SolutionConfiguration>
+  <FileVersion>1</FileVersion>
+  <InferProjectReferencesUsingAssemblyNames>false</InferProjectReferencesUsingAssemblyNames>
+  <AllowParallelTestExecution>true</AllowParallelTestExecution>
+  <AllowTestsToRunInParallelWithThemselves>true</AllowTestsToRunInParallelWithThemselves>
+  <FrameworkUtilisationTypeForNUnit>UseDynamicAnalysis</FrameworkUtilisationTypeForNUnit>
+  <FrameworkUtilisationTypeForGallio>UseStaticAnalysis</FrameworkUtilisationTypeForGallio>
+  <FrameworkUtilisationTypeForMSpec>UseStaticAnalysis</FrameworkUtilisationTypeForMSpec>
+  <FrameworkUtilisationTypeForMSTest>UseStaticAnalysis</FrameworkUtilisationTypeForMSTest>
+  <FrameworkUtilisationTypeForXUnit2>UseDynamicAnalysis</FrameworkUtilisationTypeForXUnit2>
+  <NCrunchCacheStoragePath></NCrunchCacheStoragePath>
+  <AdditionalFilesToInclude>lib\license.xml</AdditionalFilesToInclude>
+  <MetricsExclusionList>
+</MetricsExclusionList>
+</SolutionConfiguration>

--- a/src/Feature/Accounts/Tests/Sitecore.Feature.Accounts.Tests.csproj
+++ b/src/Feature/Accounts/Tests/Sitecore.Feature.Accounts.Tests.csproj
@@ -231,12 +231,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Accounts/Tests/app.config
+++ b/src/Feature/Accounts/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
       <setting name="MailServer" value="localhost" />
     </settings>
   <factories>

--- a/src/Feature/Demo/tests/Sitecore.Feature.Demo.Tests.csproj
+++ b/src/Feature/Demo/tests/Sitecore.Feature.Demo.Tests.csproj
@@ -223,12 +223,6 @@
       <Name>Sitecore.Feature.Demo</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Feature/Demo/tests/app.config
+++ b/src/Feature/Demo/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
     <outcome>
       <outcomeManager type="Sitecore.Analytics.Outcome.OutcomeManager, Sitecore.Analytics.Outcome" singleInstance="true">

--- a/src/Feature/Language/Tests/Sitecore.Feature.Language.Tests.csproj
+++ b/src/Feature/Language/Tests/Sitecore.Feature.Language.Tests.csproj
@@ -179,12 +179,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Language/Tests/app.config
+++ b/src/Feature/Language/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Maps/tests/Sitecore.Feature.Maps.Tests.csproj
+++ b/src/Feature/Maps/tests/Sitecore.Feature.Maps.Tests.csproj
@@ -183,12 +183,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Maps/tests/app.config
+++ b/src/Feature/Maps/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Media/Tests/Sitecore.Feature.Media.Tests.csproj
+++ b/src/Feature/Media/Tests/Sitecore.Feature.Media.Tests.csproj
@@ -181,12 +181,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Media/Tests/app.config
+++ b/src/Feature/Media/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Metadata/Tests/Sitecore.Feature.Metadata.Tests.csproj
+++ b/src/Feature/Metadata/Tests/Sitecore.Feature.Metadata.Tests.csproj
@@ -174,12 +174,6 @@
       <Name>Sitecore.Feature.Metadata</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Metadata/Tests/app.config
+++ b/src/Feature/Metadata/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Multisite/tests/App.config
+++ b/src/Feature/Multisite/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Multisite/tests/Sitecore.Feature.Multisite.Tests.csproj
+++ b/src/Feature/Multisite/tests/Sitecore.Feature.Multisite.Tests.csproj
@@ -184,12 +184,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/News/Tests/Sitecore.Feature.News.Tests.csproj
+++ b/src/Feature/News/Tests/Sitecore.Feature.News.Tests.csproj
@@ -206,12 +206,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/News/Tests/app.config
+++ b/src/Feature/News/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Person/tests/Sitecore.Feature.Person.Tests.csproj
+++ b/src/Feature/Person/tests/Sitecore.Feature.Person.Tests.csproj
@@ -178,12 +178,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Person/tests/app.config
+++ b/src/Feature/Person/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Search/Tests/Sitecore.Feature.Search.Tests.csproj
+++ b/src/Feature/Search/Tests/Sitecore.Feature.Search.Tests.csproj
@@ -200,12 +200,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Feature/Search/Tests/app.config
+++ b/src/Feature/Search/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Feature/Teasers/tests/App.config
+++ b/src/Feature/Teasers/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Accounts/tests/app.config
+++ b/src/Foundation/Accounts/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Alerts/tests/Sitecore.Foundation.Alerts.Tests.csproj
+++ b/src/Foundation/Alerts/tests/Sitecore.Foundation.Alerts.Tests.csproj
@@ -191,12 +191,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Alerts/tests/app.config
+++ b/src/Foundation/Alerts/tests/app.config
@@ -10,7 +10,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Dictionary/tests/app.config
+++ b/src/Foundation/Dictionary/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
       <setting name="ItemNameValidation" value="" />
     </settings>
   </sitecore>

--- a/src/Foundation/FieldEditor/tests/app.config
+++ b/src/Foundation/FieldEditor/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Forms/tests/App.config
+++ b/src/Foundation/Forms/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
+++ b/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
@@ -189,16 +189,10 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <Folder Include="ActionEditors\" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Indexing/Tests/Sitecore.Foundation.Indexing.Tests.csproj
+++ b/src/Foundation/Indexing/Tests/Sitecore.Foundation.Indexing.Tests.csproj
@@ -199,12 +199,6 @@
       <Name>Sitecore.Foundation.Indexing</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Indexing/Tests/app.config
+++ b/src/Foundation/Indexing/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Installer/tests/Sitecore.Foundation.Installer.Tests.csproj
+++ b/src/Foundation/Installer/tests/Sitecore.Foundation.Installer.Tests.csproj
@@ -183,12 +183,6 @@
       <Name>Sitecore.Foundation.Installer</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/Installer/tests/app.config
+++ b/src/Foundation/Installer/tests/app.config
@@ -16,7 +16,7 @@
   </connectionStrings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
       <setting name="Xdb.Enabled" value="true" />
     </settings>
     

--- a/src/Foundation/LocalDatasource/tests/App.config
+++ b/src/Foundation/LocalDatasource/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="\\mars\Installs\Licenses\Sitecore Partner License\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   </sitecore>
   <log4net />

--- a/src/Foundation/Multisite/tests/App.config
+++ b/src/Foundation/Multisite/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Multisite/tests/Sitecore.Foundation.Multisite.Tests.csproj
+++ b/src/Foundation/Multisite/tests/Sitecore.Foundation.Multisite.Tests.csproj
@@ -177,12 +177,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/SitecoreExtensions/Tests/Sitecore.Foundation.SitecoreExtensions.Tests.csproj
+++ b/src/Foundation/SitecoreExtensions/Tests/Sitecore.Foundation.SitecoreExtensions.Tests.csproj
@@ -221,12 +221,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Foundation/SitecoreExtensions/Tests/app.config
+++ b/src/Foundation/SitecoreExtensions/Tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Testing/tests/app.config
+++ b/src/Foundation/Testing/tests/app.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Theming/tests/App.config
+++ b/src/Foundation/Theming/tests/App.config
@@ -9,7 +9,7 @@
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value=".\license.xml" />
+      <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
   <factories>
       <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />

--- a/src/Foundation/Theming/tests/Sitecore.Foundation.Theming.Tests.csproj
+++ b/src/Foundation/Theming/tests/Sitecore.Foundation.Theming.Tests.csproj
@@ -170,12 +170,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\..\..\lib\license.xml">
-      <Link>license.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
Reconfigured all the `LicenseFile` App.config settings so that there is no need in including the license file into unit test projects. Configured [NCrunch](https://www.ncrunch.net/documentation/considerations-and-constraints_using-ncrunch-with-source-control) solution.