### PR TITLE
Make FAQ csproj for anyCPU, like all others

### DIFF
--- a/src/Feature/faq/code/Sitecore.Feature.FAQ.csproj
+++ b/src/Feature/faq/code/Sitecore.Feature.FAQ.csproj
@@ -35,7 +35,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Don't know why, but the platform target for the FAQ proj has been set to x64 CPU