### PR TITLE
Remove the FakeDb.NSubstitute package from projects that do not use it

### DIFF
--- a/src/Feature/Accounts/Tests/Sitecore.Feature.Accounts.Tests.csproj
+++ b/src/Feature/Accounts/Tests/Sitecore.Feature.Accounts.Tests.csproj
@@ -98,10 +98,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.2\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.2\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Feature/Accounts/Tests/app.config
+++ b/src/Feature/Accounts/Tests/app.config
@@ -12,9 +12,7 @@
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
       <setting name="MailServer" value="localhost" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Accounts/Tests/packages.config
+++ b/src/Feature/Accounts/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.2" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.2" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.2" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Language/Tests/Sitecore.Feature.Language.Tests.csproj
+++ b/src/Feature/Language/Tests/Sitecore.Feature.Language.Tests.csproj
@@ -85,10 +85,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/src/Feature/Language/Tests/app.config
+++ b/src/Feature/Language/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Language/Tests/packages.config
+++ b/src/Feature/Language/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Maps/tests/Sitecore.Feature.Maps.Tests.csproj
+++ b/src/Feature/Maps/tests/Sitecore.Feature.Maps.Tests.csproj
@@ -81,10 +81,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.1\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>

--- a/src/Feature/Maps/tests/app.config
+++ b/src/Feature/Maps/tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Maps/tests/packages.config
+++ b/src/Feature/Maps/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.0.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Media/Tests/Sitecore.Feature.Media.Tests.csproj
+++ b/src/Feature/Media/Tests/Sitecore.Feature.Media.Tests.csproj
@@ -86,10 +86,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Feature/Media/Tests/app.config
+++ b/src/Feature/Media/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Media/Tests/packages.config
+++ b/src/Feature/Media/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.9.2.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.0.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Metadata/Tests/Sitecore.Feature.Metadata.Tests.csproj
+++ b/src/Feature/Metadata/Tests/Sitecore.Feature.Metadata.Tests.csproj
@@ -85,10 +85,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.1\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/src/Feature/Metadata/Tests/app.config
+++ b/src/Feature/Metadata/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Metadata/Tests/packages.config
+++ b/src/Feature/Metadata/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Multisite/tests/App.config
+++ b/src/Feature/Multisite/tests/App.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Multisite/tests/Sitecore.Feature.Multisite.Tests.csproj
+++ b/src/Feature/Multisite/tests/Sitecore.Feature.Multisite.Tests.csproj
@@ -85,10 +85,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>

--- a/src/Feature/Multisite/tests/packages.config
+++ b/src/Feature/Multisite/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/News/Tests/Sitecore.Feature.News.Tests.csproj
+++ b/src/Feature/News/Tests/Sitecore.Feature.News.Tests.csproj
@@ -90,10 +90,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/src/Feature/News/Tests/app.config
+++ b/src/Feature/News/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/News/Tests/packages.config
+++ b/src/Feature/News/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Person/tests/Sitecore.Feature.Person.Tests.csproj
+++ b/src/Feature/Person/tests/Sitecore.Feature.Person.Tests.csproj
@@ -86,10 +86,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Feature/Person/tests/app.config
+++ b/src/Feature/Person/tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Person/tests/packages.config
+++ b/src/Feature/Person/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Feature/Search/Tests/Sitecore.Feature.Search.Tests.csproj
+++ b/src/Feature/Search/Tests/Sitecore.Feature.Search.Tests.csproj
@@ -90,10 +90,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Feature/Search/Tests/app.config
+++ b/src/Feature/Search/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Feature/Search/Tests/packages.config
+++ b/src/Feature/Search/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Accounts/tests/Sitecore.Foundation.Accounts.Tests.csproj
+++ b/src/Foundation/Accounts/tests/Sitecore.Foundation.Accounts.Tests.csproj
@@ -109,10 +109,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.0.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Foundation/Accounts/tests/app.config
+++ b/src/Foundation/Accounts/tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Accounts/tests/packages.config
+++ b/src/Foundation/Accounts/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.9.2.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.0.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.0.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.0.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Alerts/tests/Sitecore.Foundation.Alerts.Tests.csproj
+++ b/src/Foundation/Alerts/tests/Sitecore.Foundation.Alerts.Tests.csproj
@@ -82,10 +82,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.1\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>

--- a/src/Foundation/Alerts/tests/app.config
+++ b/src/Foundation/Alerts/tests/app.config
@@ -12,9 +12,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/src/Foundation/Alerts/tests/packages.config
+++ b/src/Foundation/Alerts/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Forms/tests/App.config
+++ b/src/Foundation/Forms/tests/App.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
+++ b/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
@@ -85,10 +85,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.1\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/src/Foundation/Forms/tests/packages.config
+++ b/src/Foundation/Forms/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Indexing/Tests/Sitecore.Foundation.Indexing.Tests.csproj
+++ b/src/Foundation/Indexing/Tests/Sitecore.Foundation.Indexing.Tests.csproj
@@ -94,10 +94,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/src/Foundation/Indexing/Tests/app.config
+++ b/src/Foundation/Indexing/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Indexing/Tests/packages.config
+++ b/src/Foundation/Indexing/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Installer/tests/Sitecore.Foundation.Installer.Tests.csproj
+++ b/src/Foundation/Installer/tests/Sitecore.Foundation.Installer.Tests.csproj
@@ -79,10 +79,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.1\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Foundation/Installer/tests/app.config
+++ b/src/Foundation/Installer/tests/app.config
@@ -20,9 +20,7 @@
       <setting name="Xdb.Enabled" value="true" />
     </settings>
     
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Installer/tests/packages.config
+++ b/src/Foundation/Installer/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Multisite/tests/App.config
+++ b/src/Foundation/Multisite/tests/App.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Multisite/tests/Sitecore.Foundation.Multisite.Tests.csproj
+++ b/src/Foundation/Multisite/tests/Sitecore.Foundation.Multisite.Tests.csproj
@@ -85,10 +85,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>

--- a/src/Foundation/Multisite/tests/packages.config
+++ b/src/Foundation/Multisite/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/SitecoreExtensions/Tests/Sitecore.Foundation.SitecoreExtensions.Tests.csproj
+++ b/src/Foundation/SitecoreExtensions/Tests/Sitecore.Foundation.SitecoreExtensions.Tests.csproj
@@ -109,10 +109,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>

--- a/src/Foundation/SitecoreExtensions/Tests/app.config
+++ b/src/Foundation/SitecoreExtensions/Tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/SitecoreExtensions/Tests/packages.config
+++ b/src/Foundation/SitecoreExtensions/Tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Testing/tests/Sitecore.Foundation.Testing.csproj
+++ b/src/Foundation/Testing/tests/Sitecore.Foundation.Testing.csproj
@@ -86,10 +86,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.0\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.1.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>

--- a/src/Foundation/Testing/tests/app.config
+++ b/src/Foundation/Testing/tests/app.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Testing/tests/packages.config
+++ b/src/Foundation/Testing/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/Foundation/Theming/tests/App.config
+++ b/src/Foundation/Theming/tests/App.config
@@ -11,9 +11,7 @@
     <settings>
       <setting name="LicenseFile" value=".\..\..\..\..\..\..\lib\license.xml" />
     </settings>
-  <factories>
-      <factory id="nsubstitute" type="Sitecore.FakeDb.NSubstitute.NSubstituteFactory, Sitecore.FakeDb.NSubstitute" />
-    </factories></sitecore>
+  </sitecore>
   <log4net />
   <system.web>
     <membership defaultProvider="fake">

--- a/src/Foundation/Theming/tests/Sitecore.Foundation.Theming.Tests.csproj
+++ b/src/Foundation/Theming/tests/Sitecore.Foundation.Theming.Tests.csproj
@@ -81,10 +81,6 @@
       <HintPath>..\..\..\..\packages\Sitecore.FakeDb.AutoFixture.1.1.1\lib\net45\Sitecore.FakeDb.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.FakeDb.NSubstitute, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Sitecore.FakeDb.NSubstitute.1.0.0\lib\net45\Sitecore.FakeDb.NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/src/Foundation/Theming/tests/packages.config
+++ b/src/Foundation/Theming/tests/packages.config
@@ -17,7 +17,6 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="Sitecore.FakeDb" version="1.1.1" targetFramework="net46" />
   <package id="Sitecore.FakeDb.AutoFixture" version="1.1.0" targetFramework="net46" />
-  <package id="Sitecore.FakeDb.NSubstitute" version="1.1.0" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />


### PR DESCRIPTION
Somebody added the [Sitecore.FakeDb.NSubstitute](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/wiki/FakeDb-NSubstitute) package to each of the test projects. In fact, the package is used in the `Sitecore.Feature.Demo.Tests` project only, so this PR removes it from all the other places.