### PR TITLE
Correct project setting for Web.config

### DIFF
--- a/src/Foundation/Testing/code/Sitecore.Foundation.Testing.csproj
+++ b/src/Foundation/Testing/code/Sitecore.Foundation.Testing.csproj
@@ -196,7 +196,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="Properties\PublishProfiles\Local.pubxml" />
-    <Content Include="web.config" />
+    <None Include="web.config" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>


### PR DESCRIPTION
Having Web.config marked as content causes this file to overwrite the Website\web.config, breaking the site.