### PR TITLE
Site Specific Assets

### DIFF
--- a/src/Foundation/Assets/code/App_Config/Include/Foundation/Foundation.Assets.config
+++ b/src/Foundation/Assets/code/App_Config/Include/Foundation/Foundation.Assets.config
@@ -5,8 +5,8 @@
         <processor
           patch:before="*[@type='Sitecore.Mvc.Pipelines.Response.GetPageRendering.GetLayoutRendering, Sitecore.Mvc']"
           type="Sitecore.Foundation.Assets.Pipelines.GetPageRendering.AddAssets, Sitecore.Foundation.Assets">
-          <defaultAssets hint="raw:AddAsset">
-          </defaultAssets>
+          <siteAssets hint="raw:AddAsset">
+          </siteAssets>
         </processor>
       </mvc.getPageRendering>
     </pipelines>

--- a/src/Foundation/Assets/code/Models/Asset.cs
+++ b/src/Foundation/Assets/code/Models/Asset.cs
@@ -1,15 +1,24 @@
 namespace Sitecore.Foundation.Assets.Models
 {
+  using System;
+
   internal class Asset
   {
-    public Asset(AssetType type, string file, ScriptLocation location = ScriptLocation.Body, string inline = null, string addOnceToken = null)
+    public Asset(AssetType type, ScriptLocation location, string file = null, string inline = null, string site = null)
     {
       this.Type = type;
       this.File = file;
       this.Location = location;
       this.Inline = inline;
-      this.AddOnceToken = addOnceToken;
+      if (!string.IsNullOrEmpty(inline))
+      {
+        this.AddOnceToken = inline.GetHashCode().ToString();
+      }
+      this.Site = site;
     }
+
+
+    public string Site { get; set; }
 
     public ScriptLocation Location { get; set; }
 

--- a/src/Foundation/Assets/code/Pipelines/GetPageRendering/AddAssets.cs
+++ b/src/Foundation/Assets/code/Pipelines/GetPageRendering/AddAssets.cs
@@ -17,22 +17,22 @@
   /// </summary>
   public class AddAssets : GetPageRenderingProcessor
   {
-    private IList<Asset> _defaultAssets;
+    private IList<Asset> _siteAssets;
 
-    private IList<Asset> DefaultAssets => this._defaultAssets ?? (this._defaultAssets = new List<Asset>());
+    private IList<Asset> SiteAssets => this._siteAssets ?? (this._siteAssets = new List<Asset>());
 
     public void AddAsset(XmlNode node)
     {
       var asset = AssetRepository.Current.CreateFromConfiguration(node);
       if (asset != null)
       {
-        this.DefaultAssets.Add(asset);
+        this.SiteAssets.Add(asset);
       }
     }
 
     public override void Process(GetPageRenderingArgs args)
     {
-      this.AddDefaultAssetsFromConfiguration();
+      this.AddSiteAssetsFromConfiguration();
 
       this.AddPageAssets(PageContext.Current.Item);
 
@@ -146,9 +146,9 @@
       return inheritedAssetItem?[assetField];
     }
 
-    private void AddDefaultAssetsFromConfiguration()
+    private void AddSiteAssetsFromConfiguration()
     {
-      foreach (var asset in this.DefaultAssets)
+      foreach (var asset in this.SiteAssets)
       {
         AssetRepository.Current.Add(asset, true);
       }

--- a/src/Foundation/Theming/code/App_Config/Include/Foundation/Foundation.Theming.Serialization.config
+++ b/src/Foundation/Theming/code/App_Config/Include/Foundation/Foundation.Theming.Serialization.config
@@ -2,7 +2,7 @@
   <sitecore>
     <unicorn>
       <configurations>
-        <configuration name="Foundation.Theming" description="Foundation Theming" dependencies="Foundation.Serialization,Foundation.SitecoreExtensions" patch:after="configuration[@name='Foundation.Serialization']">
+        <configuration name="Foundation.Theming" description="Foundation Theming" dependencies="Foundation.Serialization,Foundation.SitecoreExtensions,Foundation.Assets" patch:after="configuration[@name='Foundation.Serialization']">
           <targetDataStore physicalRootPath="$(sourceFolder)\foundation\theming\serialization" type="Rainbow.Storage.SerializationFileSystemDataStore, Rainbow" useDataCache="false" singleInstance="true" />
           <predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
             <include name="Foundation.Theming.Templates" database="master" path="/sitecore/templates/Foundation/Theming" />

--- a/src/Foundation/Theming/code/App_Config/Include/Foundation/Foundation.Theming.config
+++ b/src/Foundation/Theming/code/App_Config/Include/Foundation/Foundation.Theming.config
@@ -3,12 +3,12 @@
     <pipelines>
       <mvc.getPageRendering>
         <processor type="Sitecore.Foundation.Assets.Pipelines.GetPageRendering.AddAssets, Sitecore.Foundation.Assets">
-          <defaultAssets hint="raw:AddAsset">
+          <siteAssets hint="raw:AddAsset">
             <asset type="Css" file="/styles/vendor.min.css" />
-            <asset type="Css" file="/styles/niteflight.min.css" />
+            <asset type="Css" file="/styles/niteflight.min.css"/>
             <asset type="JavaScript" file="/scripts/Sitecore.Foundation.Theming.min.js" location="Head"/>
             <asset type="JavaScript" file="/scripts/disable-wffm-bootstrap.js" />
-          </defaultAssets>
+          </siteAssets>
         </processor>
       </mvc.getPageRendering>
     </pipelines>


### PR DESCRIPTION
Makes it possible to specify sites (or site wildcards) on the assets in the config so that css/scripts are only loaded on the pages of the specified site.