### PR TITLE
Bug38423 Fix -> Include Base Templates

### DIFF
--- a/src/Feature/Accounts/code/Services/UserProfileProvider.cs
+++ b/src/Feature/Accounts/code/Services/UserProfileProvider.cs
@@ -18,7 +18,7 @@
 
       var template = this.GetProfileTemplate(userProfile.ProfileItemId);
 
-      return template?.GetFields(false).ToDictionary(k => k.Name, v => userProfile[v.Name]) ?? new Dictionary<string, string>();
+      return template?.GetFields(true).ToDictionary(k => k.Name, v => userProfile[v.Name]) ?? new Dictionary<string, string>();
     }
 
     public void SetCustomProfile(UserProfile userProfile, IDictionary<string, string> properties)


### PR DESCRIPTION
Fix for Bug 38423: In Habitat Include Base Templates, because _LegalProfile Template now inherits from _UserProfile (Partt 2 of the fix in Sitecore.Demo)