### PR TITLE
Updated WFFM DLL references to Nuget Packages.

### DIFF
--- a/src/Foundation/Forms/code/Sitecore.Foundation.Forms.csproj
+++ b/src/Foundation/Forms/code/Sitecore.Foundation.Forms.csproj
@@ -59,17 +59,20 @@
     <Reference Include="Sitecore.Analytics.Outcome">
       <HintPath>..\..\..\..\packages\Sitecore.Analytics.Outcome.NoReferences.8.1.160519\lib\net45\Sitecore.Analytics.Outcome.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Forms.Core">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Forms.Core.dll</HintPath>
+    <Reference Include="Sitecore.Forms.Core, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Forms.Core.NoReferences.8.1.160523\lib\NET45\Sitecore.Forms.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.8.1.160519\lib\net45\Sitecore.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.WFFM.Abstractions">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.WFFM.Abstractions.dll</HintPath>
+    <Reference Include="Sitecore.WFFM.Abstractions, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.WFFM.Abstractions.NoReferences.8.1.160523\lib\NET45\Sitecore.WFFM.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.WFFM.Actions">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.WFFM.Actions.dll</HintPath>
+    <Reference Include="Sitecore.WFFM.Actions, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.WFFM.Actions.NoReferences.8.1.160523\lib\NET45\Sitecore.WFFM.Actions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/Foundation/Forms/code/packages.config
+++ b/src/Foundation/Forms/code/packages.config
@@ -5,5 +5,8 @@
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="Sitecore.Analytics.NoReferences" version="8.1.160519" targetFramework="net45" />
   <package id="Sitecore.Analytics.Outcome.NoReferences" version="8.1.160519" targetFramework="net45" />
+  <package id="Sitecore.Forms.Core.NoReferences" version="8.1.160523" targetFramework="net46" developmentDependency="true" />
   <package id="Sitecore.Kernel.NoReferences" version="8.1.160519" targetFramework="net45" />
+  <package id="Sitecore.WFFM.Abstractions.NoReferences" version="8.1.160523" targetFramework="net46" developmentDependency="true" />
+  <package id="Sitecore.WFFM.Actions.NoReferences" version="8.1.160523" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
+++ b/src/Foundation/Forms/tests/Sitecore.Foundation.Forms.Tests.csproj
@@ -137,11 +137,13 @@
     <Reference Include="sitecore.nexus">
       <HintPath>..\..\..\..\packages\sitecore.nexus.NoReferences.8.1.160519\lib\net45\sitecore.nexus.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.WFFM.Abstractions">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.WFFM.Abstractions.dll</HintPath>
+    <Reference Include="Sitecore.WFFM.Abstractions, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.WFFM.Abstractions.NoReferences.8.1.160523\lib\NET45\Sitecore.WFFM.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.WFFM.Actions">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.WFFM.Actions.dll</HintPath>
+    <Reference Include="Sitecore.WFFM.Actions, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.WFFM.Actions.NoReferences.8.1.160523\lib\NET45\Sitecore.WFFM.Actions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Foundation/Forms/tests/packages.config
+++ b/src/Foundation/Forms/tests/packages.config
@@ -32,6 +32,8 @@
   <package id="Sitecore.Logging.NoReferences" version="8.1.160519" targetFramework="net46" developmentDependency="true" />
   <package id="Sitecore.Mvc.NoReferences" version="8.1.160519" targetFramework="net46" developmentDependency="true" />
   <package id="sitecore.nexus.NoReferences" version="8.1.160519" targetFramework="net45" />
+  <package id="Sitecore.WFFM.Abstractions.NoReferences" version="8.1.160523" targetFramework="net46" developmentDependency="true" />
+  <package id="Sitecore.WFFM.Actions.NoReferences" version="8.1.160523" targetFramework="net46" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />


### PR DESCRIPTION
Now that the Sitecore WFFM Nuget Packages exist on the public NuGet server, we are able to remove the references to them from the lib\Sitecore directory, and use the NuGet packages instead.