### PR TITLE
Updated Asset Repository to not keep assets between pages

### DIFF
--- a/src/Foundation/Assets/code/Pipelines/GetPageRendering/AddAssets.cs
+++ b/src/Foundation/Assets/code/Pipelines/GetPageRendering/AddAssets.cs
@@ -32,6 +32,8 @@
 
     public override void Process(GetPageRenderingArgs args)
     {
+      AssetRepository.Current.Clear();
+
       this.AddSiteAssetsFromConfiguration();
 
       this.AddPageAssets(PageContext.Current.Item);


### PR DESCRIPTION
Should solve #203.

Making the AssetRepository ThreadStatic prevents locking so should improve performance slightly.