### PR TITLE
Gulp MsBuild Error Patch

### DIFF
--- a/gulp-config.js
+++ b/gulp-config.js
@@ -6,6 +6,7 @@ module.exports = function () {
     licensePath: instanceRoot + "\\Data\\license.xml",
     solutionName: "Habitat",
     buildConfiguration: "Debug",
+    buildPlatform: "AnyCpu",
     runCleanBuilds: false
   };
   return config;

--- a/gulp-config.js
+++ b/gulp-config.js
@@ -6,7 +6,8 @@ module.exports = function () {
     licensePath: instanceRoot + "\\Data\\license.xml",
     solutionName: "Habitat",
     buildConfiguration: "Debug",
-    buildPlatform: "AnyCpu",
+    buildPlatform: "Any CPU",
+    publishPlatform: "AnyCpu",
     runCleanBuilds: false
   };
   return config;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,7 +129,7 @@ var publishStream = function (stream, dest) {
       maxcpucount: 0,
       toolsVersion: 14.0,
       properties: {
-        Platform: config.buildPlatform,
+        Platform: config.publishPlatform,
         DeployOnBuild: "true",
         DeployDefaultTarget: "WebPublish",
         WebPublishMethod: "FileSystem",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,6 +70,7 @@ gulp.task("04-Apply-Xml-Transform", function () {
           maxcpucount: 0,
           toolsVersion: 14.0,
           properties: {
+            Platform: config.buildPlatform,
             WebConfigToTransform: config.websiteRoot,
             TransformFile: file.path,
             FileToTransform: fileToTransform
@@ -128,6 +129,7 @@ var publishStream = function (stream, dest) {
       maxcpucount: 0,
       toolsVersion: 14.0,
       properties: {
+        Platform: config.buildPlatform,
         DeployOnBuild: "true",
         DeployDefaultTarget: "WebPublish",
         WebPublishMethod: "FileSystem",
@@ -173,7 +175,10 @@ gulp.task("Build-Solution", function () {
           stdout: true,
           errorOnFail: true,
           maxcpucount: 0,
-          toolsVersion: 14.0
+          toolsVersion: 14.0,
+          properties: {
+            Platform: config.buildPlatform
+          }
         }));
 });
 


### PR DESCRIPTION
A number of colleagues were getting errors with the msbuild command in Task Runner. We tracked it down to an issue where some computers have a Windows Environment variable set that will be used for the Platform property of MsBuild when the parameter is not defined. This caused the command to fail. This pull request adds the option of setting the Platform parameter, defaulting it to 'AnyCpu', which will avoid this issue for all Windows machines. See this related thread: https://social.msdn.microsoft.com/Forums/vstudio/en-US/2253d930-fe68-4ff0-a8f2-19bfbb9a0cbb/msbuild-platformbpc?forum=msbuild.