### PR TITLE
Fix the experience editor error when no field in component template b…

### DIFF
--- a/src/Foundation/FieldEditor/code/Infrastructure/EditAllFieldsCommand.cs
+++ b/src/Foundation/FieldEditor/code/Infrastructure/EditAllFieldsCommand.cs
@@ -54,9 +54,15 @@
       return options;
     }
 
-    public override CommandState QueryState(CommandContext context)
-    {
-      return Context.PageMode.IsExperienceEditor ? CommandState.Enabled : CommandState.Hidden;
+            return options;
+        }
+
+        public override CommandState QueryState(CommandContext context)
+        {
+            return Context.PageMode.IsExperienceEditor
+                      && context.Items.Length >= 1 &&
+                      !string.IsNullOrEmpty(GetFieldsToEditService.GetFieldsToEdit(context.Items[0]))
+                      ? CommandState.Enabled : CommandState.Hidden;
+        }
     }
-  }
 }

--- a/src/Foundation/FieldEditor/code/Services/GetFieldsToEditService.cs
+++ b/src/Foundation/FieldEditor/code/Services/GetFieldsToEditService.cs
@@ -15,6 +15,10 @@ namespace Sitecore.Foundation.FieldEditor.Services
     public static string GetFieldsToEdit(Item item)
     {
       var customFields = item.Template.Fields.Where(x => !x.Name.StartsWith("__"));
+      if (!customFields.Any())
+      {
+          return String.Empty;
+      }
       var pipedFieldNames = String.Join("|", customFields.Select(f => f.Name));
       return pipedFieldNames;
     }


### PR DESCRIPTION
…mponent
![image](https://cloud.githubusercontent.com/assets/25045020/23157625/199bc642-f870-11e6-940c-56181495f0a8.png)
The edit all fields button should be hidden when there is no field to edit.

