### PR TITLE
Add return on gulp.src() in Auto-Publish-Views task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -284,7 +284,7 @@ gulp.task("Auto-Publish-Views", function () {
   var roots = [root + "/**/Views", "!" + root + "/**/obj/**/Views"];
   var files = "/**/*.cshtml";
   var destination = config.websiteRoot + "\\Views";
-  gulp.src(roots, { base: root }).pipe(
+  return gulp.src(roots, { base: root }).pipe(
     foreach(function (stream, rootFolder) {
       gulp.watch(rootFolder.path + files, function (event) {
         if (event.type === "changed") {


### PR DESCRIPTION
Fixes an issue where only a subset of the existing Views folders will be watched for changes because the result of gulp.src() was not returned