### PR TITLE
Updating ItemExtensions.cs to better handle Linkfields

### DIFF
--- a/src/Foundation/SitecoreExtensions/code/Extensions/ItemExtensions.cs
+++ b/src/Foundation/SitecoreExtensions/code/Extensions/ItemExtensions.cs
@@ -40,7 +40,7 @@
             if (mediaItem == null)
                 throw new ArgumentNullException(nameof(mediaItem));
 
-            var options = new MediaUrlOptions {Height = height, Width = width};
+            var options = new MediaUrlOptions { Height = height, Width = width };
             var url = MediaManager.GetMediaUrl(mediaItem, options);
             var cleanUrl = StringUtil.EnsurePrefix('/', url);
             var hashedUrl = HashingUtils.ProtectAssetUrl(cleanUrl);
@@ -99,14 +99,46 @@
         public static string LinkFieldUrl(this Item item, ID fieldID)
         {
             if (item == null)
+            {
                 throw new ArgumentNullException(nameof(item));
+            }
             if (ID.IsNullOrEmpty(fieldID))
+            {
                 throw new ArgumentNullException(nameof(fieldID));
+            }
             var field = item.Fields[fieldID];
-            if (field == null)
+            if (field == null || !(FieldTypeManager.GetField(field) is LinkField))
+            {
                 return string.Empty;
-            var linkUrl = new LinkUrl();
-            return linkUrl.GetUrl(item, fieldID.ToString());
+            }
+            else {
+                LinkField linkField = (LinkField)field;
+                switch (linkField.LinkType.ToLower())
+                {
+                    case "internal":
+                        // Use LinkMananger for internal links, if link is not empty
+                        return linkField.TargetItem != null ? Sitecore.Links.LinkManager.GetItemUrl(linkField.TargetItem) : string.Empty;
+                    case "media":
+                        // Use MediaManager for media links, if link is not empty
+                        return linkField.TargetItem != null ? Sitecore.Resources.Media.MediaManager.GetMediaUrl(linkField.TargetItem) : string.Empty;
+                    case "external":
+                        // Just return external links
+                        return linkField.Url;
+                    case "anchor":
+                        // Prefix anchor link with # if link if not empty
+                        return !string.IsNullOrEmpty(linkField.Anchor) ? "#" + linkField.Anchor : string.Empty;
+                    case "mailto":
+                        // Just return mailto link
+                        return linkField.Url;
+                    case "javascript":
+                        // Just return javascript
+                        return linkField.Url;
+                    default:
+                        // Just please the compiler, this
+                        // condition will never be met
+                        return linkField.Url;
+                }
+            }
         }
 
         public static string LinkFieldTarget(this Item item, ID fieldID)


### PR DESCRIPTION
This change was in response to some seemingly random errors we were getting when on a project when trying to use the LinkFieldUrl() function. It was occasionally throwing errors complaining about a missing "url" parameter. This seemed to be because older, XML based link generation functions were being used. This commit updates this function to be more robust and properly handle additional linkfield options (media, javascript, etc...) as well.