### PR TITLE
Added hostname to site config so site resolves in multisite

### DIFF
--- a/src/Project/Habitat/code/App_Config/Include/Project/Habitat.Website.config
+++ b/src/Project/Habitat/code/App_Config/Include/Project/Habitat.Website.config
@@ -29,6 +29,7 @@
         <sites>
             <site name="habitat" patch:after="site[@name='modules_website']" 
                   targetHostName="habitat.$(rootHostName)" 
+				  hostName="habitat.$(rootHostName)"
                   database="web" 
                   virtualFolder="/" 
                   physicalFolder="/" 


### PR DESCRIPTION
To create more habitat sites in the solution, the hostname needs to be set in the site config for the specific site to resolve. 