### PR TITLE
Sitemap XML and Sitemap Feature

### DIFF
--- a/src/Feature/Sitemap/code/.vs/config/applicationhost.config
+++ b/src/Feature/Sitemap/code/.vs/config/applicationhost.config
@@ -1,0 +1,1038 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    IIS configuration sections.
+
+    For schema documentation, see
+    %IIS_BIN%\config\schema\IIS_schema.xml.
+    
+    Please make a backup of this file before making any changes to it.
+
+    NOTE: The following environment variables are available to be used
+          within this file and are understood by the IIS Express.
+
+          %IIS_USER_HOME% - The IIS Express home directory for the user
+          %IIS_SITES_HOME% - The default home directory for sites
+          %IIS_BIN% - The location of the IIS Express binaries
+          %SYSTEMDRIVE% - The drive letter of %IIS_BIN%
+
+-->
+
+<configuration>
+
+    <!--
+
+        The <configSections> section controls the registration of sections.
+        Section is the basic unit of deployment, locking, searching and
+        containment for configuration settings.
+        
+        Every section belongs to one section group.
+        A section group is a container of logically-related sections.
+        
+        Sections cannot be nested.
+        Section groups may be nested.
+        
+        <section
+            name=""  [Required, Collection Key] [XML name of the section]
+            allowDefinition="Everywhere" [MachineOnly|MachineToApplication|AppHostOnly|Everywhere] [Level where it can be set]
+            overrideModeDefault="Allow"  [Allow|Deny] [Default delegation mode]
+            allowLocation="true"  [true|false] [Allowed in location tags]
+        />
+        
+        The recommended way to unlock sections is by using a location tag:
+        <location path="Default Web Site" overrideMode="Allow">
+            <system.webServer>
+                <asp />
+            </system.webServer>
+        </location>
+
+    -->
+    <configSections>
+        <sectionGroup name="system.applicationHost">
+            <section name="applicationPools" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="configHistory" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="customMetadata" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="listenerAdapters" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="log" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="preloadProviders" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="sites" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="webLimits" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+        </sectionGroup>
+
+        <sectionGroup name="system.webServer">
+            <section name="asp" overrideModeDefault="Deny" />
+            <section name="caching" overrideModeDefault="Allow" />
+            <section name="cgi" overrideModeDefault="Deny" />
+            <section name="defaultDocument" overrideModeDefault="Allow" />
+            <section name="directoryBrowse" overrideModeDefault="Allow" />
+            <section name="fastCgi" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="globalModules" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+            <section name="handlers" overrideModeDefault="Deny" />
+            <section name="httpCompression" overrideModeDefault="Allow" />
+            <section name="httpErrors" overrideModeDefault="Allow" />
+            <section name="httpLogging" overrideModeDefault="Deny" />
+            <section name="httpProtocol" overrideModeDefault="Allow" />
+            <section name="httpRedirect" overrideModeDefault="Allow" />
+            <section name="httpTracing" overrideModeDefault="Deny" />
+            <section name="isapiFilters" allowDefinition="MachineToApplication" overrideModeDefault="Deny" />
+            <section name="modules" allowDefinition="MachineToApplication" overrideModeDefault="Deny" />
+            <section name="odbcLogging" overrideModeDefault="Deny" />
+            <sectionGroup name="security">
+                <section name="access" overrideModeDefault="Deny" />
+                <section name="applicationDependencies" overrideModeDefault="Deny" />
+                <sectionGroup name="authentication">
+                    <section name="anonymousAuthentication" overrideModeDefault="Deny" />
+                    <section name="basicAuthentication" overrideModeDefault="Deny" />
+                    <section name="clientCertificateMappingAuthentication" overrideModeDefault="Deny" />
+                    <section name="digestAuthentication" overrideModeDefault="Deny" />
+                    <section name="iisClientCertificateMappingAuthentication" overrideModeDefault="Deny" />
+                    <section name="windowsAuthentication" overrideModeDefault="Deny" />
+                </sectionGroup>
+                <section name="authorization" overrideModeDefault="Allow" />
+                <section name="ipSecurity" overrideModeDefault="Deny" />
+                <section name="dynamicIpSecurity" overrideModeDefault="Deny" />
+                <section name="isapiCgiRestriction" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+                <section name="requestFiltering" overrideModeDefault="Allow" />
+            </sectionGroup>
+            <section name="serverRuntime" overrideModeDefault="Deny" />
+            <section name="serverSideInclude" overrideModeDefault="Deny" />
+            <section name="staticContent" overrideModeDefault="Allow" />
+            <sectionGroup name="tracing">
+                <section name="traceFailedRequests" overrideModeDefault="Allow" />
+                <section name="traceProviderDefinitions" overrideModeDefault="Deny" />
+            </sectionGroup>
+            <section name="urlCompression" overrideModeDefault="Allow" />
+            <section name="validation" overrideModeDefault="Allow" />
+            <sectionGroup name="webdav">
+                <section name="globalSettings" overrideModeDefault="Deny" />
+                <section name="authoring" overrideModeDefault="Deny" />
+                <section name="authoringRules" overrideModeDefault="Deny" />
+            </sectionGroup>
+            <sectionGroup name="rewrite">
+                <section name="allowedServerVariables" overrideModeDefault="Deny" />
+                <section name="rules" overrideModeDefault="Allow" />
+                <section name="outboundRules" overrideModeDefault="Allow" />
+                <section name="globalRules" overrideModeDefault="Deny" allowDefinition="AppHostOnly" />
+                <section name="providers" overrideModeDefault="Allow" />
+                <section name="rewriteMaps" overrideModeDefault="Allow" />
+            </sectionGroup>
+            <section name="applicationInitialization" allowDefinition="MachineToApplication" overrideModeDefault="Allow" />
+            <section name="webSocket" overrideModeDefault="Deny" />
+        </sectionGroup>
+    </configSections>
+
+    <configProtectedData>
+        <providers>
+            <add name="IISWASOnlyRsaProvider" type="" description="Uses RsaCryptoServiceProvider to encrypt and decrypt" keyContainerName="iisWasKey" cspProviderName="" useMachineContainer="true" useOAEP="false" />
+            <add name="AesProvider" type="Microsoft.ApplicationHost.AesProtectedConfigurationProvider" description="Uses an AES session key to encrypt and decrypt" keyContainerName="iisConfigurationKey" cspProviderName="" useOAEP="false" useMachineContainer="true" sessionKey="AQIAAA5mAAAApAAAKmFQvWHDEETRz8l2bjZlRxIkwcqTFaCUnCLljn3Q1OkesrhEO9YyLyx4bUhsj1/DyShAv7OAFFhXlrlomaornnk5PLeyO4lIXxaiT33yOFUUgxDx4GSaygkqghVV0tO5yQ/XguUBp2juMfZyztnsNa4pLcz7ZNZQ6p4yn9hxwNs=" />
+            <add name="IISWASOnlyAesProvider" type="Microsoft.ApplicationHost.AesProtectedConfigurationProvider" description="Uses an AES session key to encrypt and decrypt" keyContainerName="iisWasKey" cspProviderName="" useOAEP="false" useMachineContainer="true" sessionKey="AQIAAA5mAAAApAAA4WoiRJ8KHwzAG8AgejPxEOO4/2Vhkolbwo/8gZeNdUDSD36m55hWv4uC9tr/MlKdnwRLL0NhT50Gccyftqz5xTZ0dg5FtvQhTw/he1NwexTKbV+I4Zrd+sZUqHZTsr7JiEr6OHGXL70qoISW5G2m9U8wKT3caPiDPNj2aAaYPLo=" />
+        </providers>
+    </configProtectedData>
+
+    <system.applicationHost>
+
+        <applicationPools>
+            <add name="Clr4IntegratedAppPool" managedRuntimeVersion="v4.0" managedPipelineMode="Integrated" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+            <add name="Clr4ClassicAppPool" managedRuntimeVersion="v4.0" managedPipelineMode="Classic" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+            <add name="Clr2IntegratedAppPool" managedRuntimeVersion="v2.0" managedPipelineMode="Integrated" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+            <add name="Clr2ClassicAppPool" managedRuntimeVersion="v2.0" managedPipelineMode="Classic" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+            <add name="UnmanagedClassicAppPool" managedRuntimeVersion="" managedPipelineMode="Classic" autoStart="true" />
+            <applicationPoolDefaults managedRuntimeLoader="v4.0">
+                <processModel />
+            </applicationPoolDefaults>
+        </applicationPools>
+
+        <!--
+
+          The <listenerAdapters> section defines the protocols with which the
+          Windows Process Activation Service (WAS) binds.
+
+        -->
+        <listenerAdapters>
+            <add name="http" />
+        </listenerAdapters>
+
+        <sites>
+            <site name="WebSite1" id="1" serverAutoStart="true">
+                <application path="/">
+                    <virtualDirectory path="/" physicalPath="%IIS_SITES_HOME%\WebSite1" />
+                </application>
+                <bindings>
+                    <binding protocol="http" bindingInformation=":8080:localhost" />
+                </bindings>
+            </site>
+            <site name="Habitat.Article" id="2">
+                <application path="/" applicationPool="Clr4IntegratedAppPool">
+                    <virtualDirectory path="/" physicalPath="C:\Projects\Habitat\src\Domain\Article" />
+                </application>
+                <bindings>
+                    <binding protocol="http" bindingInformation="*:59548:localhost" />
+                </bindings>
+            </site>
+            <siteDefaults>
+                <logFile logFormat="W3C" directory="%IIS_USER_HOME%\Logs" />
+                <traceFailedRequestsLogging directory="%IIS_USER_HOME%\TraceLogFiles" enabled="true" maxLogFileSizeKB="1024" />
+            </siteDefaults>
+            <applicationDefaults applicationPool="Clr4IntegratedAppPool" />
+            <virtualDirectoryDefaults allowSubDirConfig="true" />
+        </sites>
+
+        <webLimits />
+
+    </system.applicationHost>
+
+    <system.webServer>
+
+        <serverRuntime />
+
+        <asp scriptErrorSentToBrowser="true">
+            <cache diskTemplateCacheDirectory="%TEMP%\iisexpress\ASP Compiled Templates" />
+            <limits />
+        </asp>
+
+        <caching enabled="true" enableKernelCache="true">
+        </caching>
+
+        <cgi />
+
+        <defaultDocument enabled="true">
+            <files>
+                <add value="Default.htm" />
+                <add value="Default.asp" />
+                <add value="index.htm" />
+                <add value="index.html" />
+                <add value="iisstart.htm" />
+                <add value="default.aspx" />
+            </files>
+        </defaultDocument>
+
+        <directoryBrowse enabled="false" />
+
+        <fastCgi />
+
+        <!--
+
+          The <globalModules> section defines all native-code modules.
+          To enable a module, specify it in the <modules> section.
+
+        -->
+        <globalModules>
+            <add name="HttpLoggingModule" image="%IIS_BIN%\loghttp.dll" />
+            <add name="UriCacheModule" image="%IIS_BIN%\cachuri.dll" />
+<!--            <add name="FileCacheModule" image="%IIS_BIN%\cachfile.dll" />  -->
+            <add name="TokenCacheModule" image="%IIS_BIN%\cachtokn.dll" />
+<!--            <add name="HttpCacheModule" image="%IIS_BIN%\cachhttp.dll" /> -->
+            <add name="DynamicCompressionModule" image="%IIS_BIN%\compdyn.dll" />
+            <add name="StaticCompressionModule" image="%IIS_BIN%\compstat.dll" />
+            <add name="DefaultDocumentModule" image="%IIS_BIN%\defdoc.dll" />
+            <add name="DirectoryListingModule" image="%IIS_BIN%\dirlist.dll" />
+            <add name="ProtocolSupportModule" image="%IIS_BIN%\protsup.dll" />
+            <add name="HttpRedirectionModule" image="%IIS_BIN%\redirect.dll" />
+            <add name="ServerSideIncludeModule" image="%IIS_BIN%\iis_ssi.dll" />
+            <add name="StaticFileModule" image="%IIS_BIN%\static.dll" />
+            <add name="AnonymousAuthenticationModule" image="%IIS_BIN%\authanon.dll" />
+            <add name="CertificateMappingAuthenticationModule" image="%IIS_BIN%\authcert.dll" />
+            <add name="UrlAuthorizationModule" image="%IIS_BIN%\urlauthz.dll" />
+            <add name="BasicAuthenticationModule" image="%IIS_BIN%\authbas.dll" />
+            <add name="WindowsAuthenticationModule" image="%IIS_BIN%\authsspi.dll" />
+<!--            <add name="DigestAuthenticationModule" image="%IIS_BIN%\authmd5.dll" /> -->
+            <add name="IISCertificateMappingAuthenticationModule" image="%IIS_BIN%\authmap.dll" />
+            <add name="IpRestrictionModule" image="%IIS_BIN%\iprestr.dll" />
+            <add name="DynamicIpRestrictionModule" image="%IIS_BIN%\diprestr.dll" />
+            <add name="RequestFilteringModule" image="%IIS_BIN%\modrqflt.dll" />
+            <add name="CustomLoggingModule" image="%IIS_BIN%\logcust.dll" />
+            <add name="CustomErrorModule" image="%IIS_BIN%\custerr.dll" />
+<!--            <add name="TracingModule" image="%IIS_BIN%\iisetw.dll" /> -->
+            <add name="FailedRequestsTracingModule" image="%IIS_BIN%\iisfreb.dll" />
+            <add name="RequestMonitorModule" image="%IIS_BIN%\iisreqs.dll" />
+            <add name="IsapiModule" image="%IIS_BIN%\isapi.dll" />
+            <add name="IsapiFilterModule" image="%IIS_BIN%\filter.dll" />
+            <add name="CgiModule" image="%IIS_BIN%\cgi.dll" />
+            <add name="FastCgiModule" image="%IIS_BIN%\iisfcgi.dll" />
+<!--            <add name="WebDAVModule" image="%IIS_BIN%\webdav.dll" /> -->
+            <add name="RewriteModule" image="%IIS_BIN%\rewrite.dll" />
+            <add name="ConfigurationValidationModule" image="%IIS_BIN%\validcfg.dll" />
+            <add name="WebSocketModule" image="%IIS_BIN%\iiswsock.dll" />
+            <add name="WebMatrixSupportModule" image="%IIS_BIN%\webmatrixsup.dll" />
+            <add name="ManagedEngine" image="%windir%\Microsoft.NET\Framework\v2.0.50727\webengine.dll" preCondition="integratedMode,runtimeVersionv2.0,bitness32" />
+            <add name="ManagedEngine64" image="%windir%\Microsoft.NET\Framework64\v2.0.50727\webengine.dll" preCondition="integratedMode,runtimeVersionv2.0,bitness64" />
+            <add name="ManagedEngineV4.0_32bit" image="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness32" />
+            <add name="ManagedEngineV4.0_64bit" image="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness64" />
+            <add name="ApplicationInitializationModule" image="%IIS_BIN%\warmup.dll" />
+        </globalModules>
+
+        <httpCompression directory="%TEMP%\iisexpress\IIS Temporary Compressed Files">
+            <scheme name="gzip" dll="%IIS_BIN%\gzip.dll" />
+            <dynamicTypes>
+                <add mimeType="text/*" enabled="true" />
+                <add mimeType="message/*" enabled="true" />
+                <add mimeType="application/javascript" enabled="true" />
+                <add mimeType="application/atom+xml" enabled="true" />
+                <add mimeType="application/xaml+xml" enabled="true" />
+                <add mimeType="*/*" enabled="false" />
+            </dynamicTypes>
+            <staticTypes>
+                <add mimeType="text/*" enabled="true" />
+                <add mimeType="message/*" enabled="true" />
+                <add mimeType="image/svg+xml" enabled="true" />
+                <add mimeType="application/javascript" enabled="true" />
+                <add mimeType="application/atom+xml" enabled="true" />
+                <add mimeType="application/xaml+xml" enabled="true" />
+                <add mimeType="*/*" enabled="false" />
+            </staticTypes>
+        </httpCompression>
+
+        <httpErrors lockAttributes="allowAbsolutePathsWhenDelegated,defaultPath">
+            <error statusCode="401" prefixLanguageFilePath="%IIS_BIN%\custerr" path="401.htm" />
+            <error statusCode="403" prefixLanguageFilePath="%IIS_BIN%\custerr" path="403.htm" />
+            <error statusCode="404" prefixLanguageFilePath="%IIS_BIN%\custerr" path="404.htm" />
+            <error statusCode="405" prefixLanguageFilePath="%IIS_BIN%\custerr" path="405.htm" />
+            <error statusCode="406" prefixLanguageFilePath="%IIS_BIN%\custerr" path="406.htm" />
+            <error statusCode="412" prefixLanguageFilePath="%IIS_BIN%\custerr" path="412.htm" />
+            <error statusCode="500" prefixLanguageFilePath="%IIS_BIN%\custerr" path="500.htm" />
+            <error statusCode="501" prefixLanguageFilePath="%IIS_BIN%\custerr" path="501.htm" />
+            <error statusCode="502" prefixLanguageFilePath="%IIS_BIN%\custerr" path="502.htm" />
+        </httpErrors>
+
+        <httpLogging dontLog="false" />
+
+        <httpProtocol>
+            <customHeaders>
+                <clear />
+                <add name="X-Powered-By" value="ASP.NET" />
+            </customHeaders>
+            <redirectHeaders>
+                <clear />
+            </redirectHeaders>
+        </httpProtocol>
+
+        <httpRedirect enabled="false" />
+
+        <httpTracing>
+        </httpTracing>
+
+        <isapiFilters>
+            <filter name="ASP.Net_2.0.50727-64" path="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="bitness64,runtimeVersionv2.0" />
+            <filter name="ASP.Net_2.0.50727.0" path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="bitness32,runtimeVersionv2.0" />
+            <filter name="ASP.Net_2.0_for_v1.1" path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="runtimeVersionv1.1" />
+            <filter name="ASP.Net_4.0_32bit" path="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_filter.dll" enableCache="true" preCondition="bitness32,runtimeVersionv4.0" />
+            <filter name="ASP.Net_4.0_64bit" path="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_filter.dll" enableCache="true" preCondition="bitness64,runtimeVersionv4.0" />
+        </isapiFilters>
+
+        <odbcLogging />
+
+        <security>
+
+            <access sslFlags="None" />
+
+            <applicationDependencies>
+                <application name="Active Server Pages" groupId="ASP" />
+            </applicationDependencies>
+
+            <authentication>
+
+                <anonymousAuthentication enabled="true" userName="" />
+
+                <basicAuthentication enabled="false" />
+
+                <clientCertificateMappingAuthentication enabled="false" />
+
+                <digestAuthentication enabled="false" />
+
+                <iisClientCertificateMappingAuthentication enabled="false">
+                </iisClientCertificateMappingAuthentication>
+
+                <windowsAuthentication enabled="false">
+                    <providers>
+                        <add value="Negotiate" />
+                        <add value="NTLM" />
+                    </providers>
+                </windowsAuthentication>
+
+            </authentication>
+
+            <authorization>
+                <add accessType="Allow" users="*" />
+            </authorization>
+
+            <ipSecurity allowUnlisted="true" />
+
+            <isapiCgiRestriction notListedIsapisAllowed="true" notListedCgisAllowed="true">
+                <add path="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" allowed="true" groupId="ASP.NET_v4.0" description="ASP.NET_v4.0" />
+                <add path="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" allowed="true" groupId="ASP.NET_v4.0" description="ASP.NET_v4.0" />
+                <add path="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v2.0.50727" description="ASP.NET v2.0.50727" />
+                <add path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v2.0.50727" description="ASP.NET v2.0.50727" />
+            </isapiCgiRestriction>
+
+            <requestFiltering>
+                <fileExtensions allowUnlisted="true" applyToWebDAV="true">
+                    <add fileExtension=".asa" allowed="false" />
+                    <add fileExtension=".asax" allowed="false" />
+                    <add fileExtension=".ascx" allowed="false" />
+                    <add fileExtension=".master" allowed="false" />
+                    <add fileExtension=".skin" allowed="false" />
+                    <add fileExtension=".browser" allowed="false" />
+                    <add fileExtension=".sitemap" allowed="false" />
+                    <add fileExtension=".config" allowed="false" />
+                    <add fileExtension=".cs" allowed="false" />
+                    <add fileExtension=".csproj" allowed="false" />
+                    <add fileExtension=".vb" allowed="false" />
+                    <add fileExtension=".vbproj" allowed="false" />
+                    <add fileExtension=".webinfo" allowed="false" />
+                    <add fileExtension=".licx" allowed="false" />
+                    <add fileExtension=".resx" allowed="false" />
+                    <add fileExtension=".resources" allowed="false" />
+                    <add fileExtension=".mdb" allowed="false" />
+                    <add fileExtension=".vjsproj" allowed="false" />
+                    <add fileExtension=".java" allowed="false" />
+                    <add fileExtension=".jsl" allowed="false" />
+                    <add fileExtension=".ldb" allowed="false" />
+                    <add fileExtension=".dsdgm" allowed="false" />
+                    <add fileExtension=".ssdgm" allowed="false" />
+                    <add fileExtension=".lsad" allowed="false" />
+                    <add fileExtension=".ssmap" allowed="false" />
+                    <add fileExtension=".cd" allowed="false" />
+                    <add fileExtension=".dsprototype" allowed="false" />
+                    <add fileExtension=".lsaprototype" allowed="false" />
+                    <add fileExtension=".sdm" allowed="false" />
+                    <add fileExtension=".sdmDocument" allowed="false" />
+                    <add fileExtension=".mdf" allowed="false" />
+                    <add fileExtension=".ldf" allowed="false" />
+                    <add fileExtension=".ad" allowed="false" />
+                    <add fileExtension=".dd" allowed="false" />
+                    <add fileExtension=".ldd" allowed="false" />
+                    <add fileExtension=".sd" allowed="false" />
+                    <add fileExtension=".adprototype" allowed="false" />
+                    <add fileExtension=".lddprototype" allowed="false" />
+                    <add fileExtension=".exclude" allowed="false" />
+                    <add fileExtension=".refresh" allowed="false" />
+                    <add fileExtension=".compiled" allowed="false" />
+                    <add fileExtension=".msgx" allowed="false" />
+                    <add fileExtension=".vsdisco" allowed="false" />
+                    <add fileExtension=".rules" allowed="false" />
+                </fileExtensions>
+                <verbs allowUnlisted="true" applyToWebDAV="true" />
+                <hiddenSegments applyToWebDAV="true">
+                    <add segment="web.config" />
+                    <add segment="bin" />
+                    <add segment="App_code" />
+                    <add segment="App_GlobalResources" />
+                    <add segment="App_LocalResources" />
+                    <add segment="App_WebReferences" />
+                    <add segment="App_Data" />
+                    <add segment="App_Browsers" />
+                </hiddenSegments>
+            </requestFiltering>
+
+        </security>
+
+        <serverSideInclude ssiExecDisable="false" />
+
+        <staticContent lockAttributes="isDocFooterFileName">
+            <mimeMap fileExtension=".323" mimeType="text/h323" />
+            <mimeMap fileExtension=".3g2" mimeType="video/3gpp2" />
+            <mimeMap fileExtension=".3gp2" mimeType="video/3gpp2" />
+            <mimeMap fileExtension=".3gp" mimeType="video/3gpp" />
+            <mimeMap fileExtension=".3gpp" mimeType="video/3gpp" />
+            <mimeMap fileExtension=".aac" mimeType="audio/aac" />
+            <mimeMap fileExtension=".aaf" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".aca" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".accdb" mimeType="application/msaccess" />
+            <mimeMap fileExtension=".accde" mimeType="application/msaccess" />
+            <mimeMap fileExtension=".accdt" mimeType="application/msaccess" />
+            <mimeMap fileExtension=".acx" mimeType="application/internet-property-stream" />
+            <mimeMap fileExtension=".adt" mimeType="audio/vnd.dlna.adts" />
+            <mimeMap fileExtension=".adts" mimeType="audio/vnd.dlna.adts" />
+            <mimeMap fileExtension=".afm" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".ai" mimeType="application/postscript" />
+            <mimeMap fileExtension=".aif" mimeType="audio/x-aiff" />
+            <mimeMap fileExtension=".aifc" mimeType="audio/aiff" />
+            <mimeMap fileExtension=".aiff" mimeType="audio/aiff" />
+            <mimeMap fileExtension=".appcache" mimeType="text/cache-manifest" />
+            <mimeMap fileExtension=".application" mimeType="application/x-ms-application" />
+            <mimeMap fileExtension=".art" mimeType="image/x-jg" />
+            <mimeMap fileExtension=".asd" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".asf" mimeType="video/x-ms-asf" />
+            <mimeMap fileExtension=".asi" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".asm" mimeType="text/plain" />
+            <mimeMap fileExtension=".asr" mimeType="video/x-ms-asf" />
+            <mimeMap fileExtension=".asx" mimeType="video/x-ms-asf" />
+            <mimeMap fileExtension=".atom" mimeType="application/atom+xml" />
+            <mimeMap fileExtension=".au" mimeType="audio/basic" />
+            <mimeMap fileExtension=".avi" mimeType="video/msvideo" />
+            <mimeMap fileExtension=".axs" mimeType="application/olescript" />
+            <mimeMap fileExtension=".bas" mimeType="text/plain" />
+            <mimeMap fileExtension=".bcpio" mimeType="application/x-bcpio" />
+            <mimeMap fileExtension=".bin" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".bmp" mimeType="image/bmp" />
+            <mimeMap fileExtension=".c" mimeType="text/plain" />
+            <mimeMap fileExtension=".cab" mimeType="application/vnd.ms-cab-compressed" />
+            <mimeMap fileExtension=".calx" mimeType="application/vnd.ms-office.calx" />
+            <mimeMap fileExtension=".cat" mimeType="application/vnd.ms-pki.seccat" />
+            <mimeMap fileExtension=".cdf" mimeType="application/x-cdf" />
+            <mimeMap fileExtension=".chm" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".class" mimeType="application/x-java-applet" />
+            <mimeMap fileExtension=".clp" mimeType="application/x-msclip" />
+            <mimeMap fileExtension=".cmx" mimeType="image/x-cmx" />
+            <mimeMap fileExtension=".cnf" mimeType="text/plain" />
+            <mimeMap fileExtension=".cod" mimeType="image/cis-cod" />
+            <mimeMap fileExtension=".cpio" mimeType="application/x-cpio" />
+            <mimeMap fileExtension=".cpp" mimeType="text/plain" />
+            <mimeMap fileExtension=".crd" mimeType="application/x-mscardfile" />
+            <mimeMap fileExtension=".crl" mimeType="application/pkix-crl" />
+            <mimeMap fileExtension=".crt" mimeType="application/x-x509-ca-cert" />
+            <mimeMap fileExtension=".csh" mimeType="application/x-csh" />
+            <mimeMap fileExtension=".css" mimeType="text/css" />
+            <mimeMap fileExtension=".csv" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".cur" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".dcr" mimeType="application/x-director" />
+            <mimeMap fileExtension=".deploy" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".der" mimeType="application/x-x509-ca-cert" />
+            <mimeMap fileExtension=".dib" mimeType="image/bmp" />
+            <mimeMap fileExtension=".dir" mimeType="application/x-director" />
+            <mimeMap fileExtension=".disco" mimeType="text/xml" />
+            <mimeMap fileExtension=".dll" mimeType="application/x-msdownload" />
+            <mimeMap fileExtension=".dll.config" mimeType="text/xml" />
+            <mimeMap fileExtension=".dlm" mimeType="text/dlm" />
+            <mimeMap fileExtension=".doc" mimeType="application/msword" />
+            <mimeMap fileExtension=".docm" mimeType="application/vnd.ms-word.document.macroEnabled.12" />
+            <mimeMap fileExtension=".docx" mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+            <mimeMap fileExtension=".dot" mimeType="application/msword" />
+            <mimeMap fileExtension=".dotm" mimeType="application/vnd.ms-word.template.macroEnabled.12" />
+            <mimeMap fileExtension=".dotx" mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.template" />
+            <mimeMap fileExtension=".dsp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".dtd" mimeType="text/xml" />
+            <mimeMap fileExtension=".dvi" mimeType="application/x-dvi" />
+            <mimeMap fileExtension=".dvr-ms" mimeType="video/x-ms-dvr" />
+            <mimeMap fileExtension=".dwf" mimeType="drawing/x-dwf" />
+            <mimeMap fileExtension=".dwp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".dxr" mimeType="application/x-director" />
+            <mimeMap fileExtension=".eml" mimeType="message/rfc822" />
+            <mimeMap fileExtension=".emz" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
+            <mimeMap fileExtension=".eps" mimeType="application/postscript" />
+            <mimeMap fileExtension=".etx" mimeType="text/x-setext" />
+            <mimeMap fileExtension=".evy" mimeType="application/envoy" />
+            <mimeMap fileExtension=".exe" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".exe.config" mimeType="text/xml" />
+            <mimeMap fileExtension=".fdf" mimeType="application/vnd.fdf" />
+            <mimeMap fileExtension=".fif" mimeType="application/fractals" />
+            <mimeMap fileExtension=".fla" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".flr" mimeType="x-world/x-vrml" />
+            <mimeMap fileExtension=".flv" mimeType="video/x-flv" />
+            <mimeMap fileExtension=".gif" mimeType="image/gif" />
+            <mimeMap fileExtension=".gtar" mimeType="application/x-gtar" />
+            <mimeMap fileExtension=".gz" mimeType="application/x-gzip" />
+            <mimeMap fileExtension=".h" mimeType="text/plain" />
+            <mimeMap fileExtension=".hdf" mimeType="application/x-hdf" />
+            <mimeMap fileExtension=".hdml" mimeType="text/x-hdml" />
+            <mimeMap fileExtension=".hhc" mimeType="application/x-oleobject" />
+            <mimeMap fileExtension=".hhk" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".hhp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".hlp" mimeType="application/winhlp" />
+            <mimeMap fileExtension=".hqx" mimeType="application/mac-binhex40" />
+            <mimeMap fileExtension=".hta" mimeType="application/hta" />
+            <mimeMap fileExtension=".htc" mimeType="text/x-component" />
+            <mimeMap fileExtension=".htm" mimeType="text/html" />
+            <mimeMap fileExtension=".html" mimeType="text/html" />
+            <mimeMap fileExtension=".htt" mimeType="text/webviewhtml" />
+            <mimeMap fileExtension=".hxt" mimeType="text/html" />
+            <mimeMap fileExtension=".ico" mimeType="image/x-icon" />
+            <mimeMap fileExtension=".ics" mimeType="text/calendar" />
+            <mimeMap fileExtension=".ief" mimeType="image/ief" />
+            <mimeMap fileExtension=".iii" mimeType="application/x-iphone" />
+            <mimeMap fileExtension=".inf" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".ins" mimeType="application/x-internet-signup" />
+            <mimeMap fileExtension=".isp" mimeType="application/x-internet-signup" />
+            <mimeMap fileExtension=".IVF" mimeType="video/x-ivf" />
+            <mimeMap fileExtension=".jar" mimeType="application/java-archive" />
+            <mimeMap fileExtension=".java" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".jck" mimeType="application/liquidmotion" />
+            <mimeMap fileExtension=".jcz" mimeType="application/liquidmotion" />
+            <mimeMap fileExtension=".jfif" mimeType="image/pjpeg" />
+            <mimeMap fileExtension=".jpb" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".jpe" mimeType="image/jpeg" />
+            <mimeMap fileExtension=".jpeg" mimeType="image/jpeg" />
+            <mimeMap fileExtension=".jpg" mimeType="image/jpeg" />
+            <mimeMap fileExtension=".js" mimeType="application/javascript" />
+            <mimeMap fileExtension=".json" mimeType="application/json" />
+            <mimeMap fileExtension=".jsonld" mimeType="application/ld+json" />
+            <mimeMap fileExtension=".jsx" mimeType="text/jscript" />
+            <mimeMap fileExtension=".latex" mimeType="application/x-latex" />
+            <mimeMap fileExtension=".less" mimeType="text/css" />
+            <mimeMap fileExtension=".lit" mimeType="application/x-ms-reader" />
+            <mimeMap fileExtension=".lpk" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".lsf" mimeType="video/x-la-asf" />
+            <mimeMap fileExtension=".lsx" mimeType="video/x-la-asf" />
+            <mimeMap fileExtension=".lzh" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".m13" mimeType="application/x-msmediaview" />
+            <mimeMap fileExtension=".m14" mimeType="application/x-msmediaview" />
+            <mimeMap fileExtension=".m1v" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".m2ts" mimeType="video/vnd.dlna.mpeg-tts" />
+            <mimeMap fileExtension=".m3u" mimeType="audio/x-mpegurl" />
+            <mimeMap fileExtension=".m4a" mimeType="audio/mp4" />
+            <mimeMap fileExtension=".m4v" mimeType="video/mp4" />
+            <mimeMap fileExtension=".man" mimeType="application/x-troff-man" />
+            <mimeMap fileExtension=".manifest" mimeType="application/x-ms-manifest" />
+            <mimeMap fileExtension=".map" mimeType="text/plain" />
+            <mimeMap fileExtension=".mdb" mimeType="application/x-msaccess" />
+            <mimeMap fileExtension=".mdp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".me" mimeType="application/x-troff-me" />
+            <mimeMap fileExtension=".mht" mimeType="message/rfc822" />
+            <mimeMap fileExtension=".mhtml" mimeType="message/rfc822" />
+            <mimeMap fileExtension=".mid" mimeType="audio/mid" />
+            <mimeMap fileExtension=".midi" mimeType="audio/mid" />
+            <mimeMap fileExtension=".mix" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".mmf" mimeType="application/x-smaf" />
+            <mimeMap fileExtension=".mno" mimeType="text/xml" />
+            <mimeMap fileExtension=".mny" mimeType="application/x-msmoney" />
+            <mimeMap fileExtension=".mov" mimeType="video/quicktime" />
+            <mimeMap fileExtension=".movie" mimeType="video/x-sgi-movie" />
+            <mimeMap fileExtension=".mp2" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".mp3" mimeType="audio/mpeg" />
+            <mimeMap fileExtension=".mp4" mimeType="video/mp4" />
+            <mimeMap fileExtension=".mp4v" mimeType="video/mp4" />
+            <mimeMap fileExtension=".mpa" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".mpe" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".mpeg" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".mpg" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".mpp" mimeType="application/vnd.ms-project" />
+            <mimeMap fileExtension=".mpv2" mimeType="video/mpeg" />
+            <mimeMap fileExtension=".ms" mimeType="application/x-troff-ms" />
+            <mimeMap fileExtension=".msi" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".mso" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".mvb" mimeType="application/x-msmediaview" />
+            <mimeMap fileExtension=".mvc" mimeType="application/x-miva-compiled" />
+            <mimeMap fileExtension=".nc" mimeType="application/x-netcdf" />
+            <mimeMap fileExtension=".nsc" mimeType="video/x-ms-asf" />
+            <mimeMap fileExtension=".nws" mimeType="message/rfc822" />
+            <mimeMap fileExtension=".ocx" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".oda" mimeType="application/oda" />
+            <mimeMap fileExtension=".odc" mimeType="text/x-ms-odc" />
+            <mimeMap fileExtension=".ods" mimeType="application/oleobject" />
+            <mimeMap fileExtension=".oga" mimeType="audio/ogg" />
+            <mimeMap fileExtension=".ogg" mimeType="video/ogg" />
+            <mimeMap fileExtension=".ogv" mimeType="video/ogg" />
+            <mimeMap fileExtension=".one" mimeType="application/onenote" />
+            <mimeMap fileExtension=".onea" mimeType="application/onenote" />
+            <mimeMap fileExtension=".onetoc" mimeType="application/onenote" />
+            <mimeMap fileExtension=".onetoc2" mimeType="application/onenote" />
+            <mimeMap fileExtension=".onetmp" mimeType="application/onenote" />
+            <mimeMap fileExtension=".onepkg" mimeType="application/onenote" />
+            <mimeMap fileExtension=".osdx" mimeType="application/opensearchdescription+xml" />
+            <mimeMap fileExtension=".otf" mimeType="font/otf" />
+            <mimeMap fileExtension=".p10" mimeType="application/pkcs10" />
+            <mimeMap fileExtension=".p12" mimeType="application/x-pkcs12" />
+            <mimeMap fileExtension=".p7b" mimeType="application/x-pkcs7-certificates" />
+            <mimeMap fileExtension=".p7c" mimeType="application/pkcs7-mime" />
+            <mimeMap fileExtension=".p7m" mimeType="application/pkcs7-mime" />
+            <mimeMap fileExtension=".p7r" mimeType="application/x-pkcs7-certreqresp" />
+            <mimeMap fileExtension=".p7s" mimeType="application/pkcs7-signature" />
+            <mimeMap fileExtension=".pbm" mimeType="image/x-portable-bitmap" />
+            <mimeMap fileExtension=".pcx" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".pcz" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".pdf" mimeType="application/pdf" />
+            <mimeMap fileExtension=".pfb" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".pfm" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".pfx" mimeType="application/x-pkcs12" />
+            <mimeMap fileExtension=".pgm" mimeType="image/x-portable-graymap" />
+            <mimeMap fileExtension=".pko" mimeType="application/vnd.ms-pki.pko" />
+            <mimeMap fileExtension=".pma" mimeType="application/x-perfmon" />
+            <mimeMap fileExtension=".pmc" mimeType="application/x-perfmon" />
+            <mimeMap fileExtension=".pml" mimeType="application/x-perfmon" />
+            <mimeMap fileExtension=".pmr" mimeType="application/x-perfmon" />
+            <mimeMap fileExtension=".pmw" mimeType="application/x-perfmon" />
+            <mimeMap fileExtension=".png" mimeType="image/png" />
+            <mimeMap fileExtension=".pnm" mimeType="image/x-portable-anymap" />
+            <mimeMap fileExtension=".pnz" mimeType="image/png" />
+            <mimeMap fileExtension=".pot" mimeType="application/vnd.ms-powerpoint" />
+            <mimeMap fileExtension=".potm" mimeType="application/vnd.ms-powerpoint.template.macroEnabled.12" />
+            <mimeMap fileExtension=".potx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.template" />
+            <mimeMap fileExtension=".ppam" mimeType="application/vnd.ms-powerpoint.addin.macroEnabled.12" />
+            <mimeMap fileExtension=".ppm" mimeType="image/x-portable-pixmap" />
+            <mimeMap fileExtension=".pps" mimeType="application/vnd.ms-powerpoint" />
+            <mimeMap fileExtension=".ppsm" mimeType="application/vnd.ms-powerpoint.slideshow.macroEnabled.12" />
+            <mimeMap fileExtension=".ppsx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.slideshow" />
+            <mimeMap fileExtension=".ppt" mimeType="application/vnd.ms-powerpoint" />
+            <mimeMap fileExtension=".pptm" mimeType="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
+            <mimeMap fileExtension=".pptx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.presentation" />
+            <mimeMap fileExtension=".prf" mimeType="application/pics-rules" />
+            <mimeMap fileExtension=".prm" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".prx" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".ps" mimeType="application/postscript" />
+            <mimeMap fileExtension=".psd" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".psm" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".psp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".pub" mimeType="application/x-mspublisher" />
+            <mimeMap fileExtension=".qt" mimeType="video/quicktime" />
+            <mimeMap fileExtension=".qtl" mimeType="application/x-quicktimeplayer" />
+            <mimeMap fileExtension=".qxd" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".ra" mimeType="audio/x-pn-realaudio" />
+            <mimeMap fileExtension=".ram" mimeType="audio/x-pn-realaudio" />
+            <mimeMap fileExtension=".rar" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".ras" mimeType="image/x-cmu-raster" />
+            <mimeMap fileExtension=".rf" mimeType="image/vnd.rn-realflash" />
+            <mimeMap fileExtension=".rgb" mimeType="image/x-rgb" />
+            <mimeMap fileExtension=".rm" mimeType="application/vnd.rn-realmedia" />
+            <mimeMap fileExtension=".rmi" mimeType="audio/mid" />
+            <mimeMap fileExtension=".roff" mimeType="application/x-troff" />
+            <mimeMap fileExtension=".rpm" mimeType="audio/x-pn-realaudio-plugin" />
+            <mimeMap fileExtension=".rtf" mimeType="application/rtf" />
+            <mimeMap fileExtension=".rtx" mimeType="text/richtext" />
+            <mimeMap fileExtension=".scd" mimeType="application/x-msschedule" />
+            <mimeMap fileExtension=".sct" mimeType="text/scriptlet" />
+            <mimeMap fileExtension=".sea" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".setpay" mimeType="application/set-payment-initiation" />
+            <mimeMap fileExtension=".setreg" mimeType="application/set-registration-initiation" />
+            <mimeMap fileExtension=".sgml" mimeType="text/sgml" />
+            <mimeMap fileExtension=".sh" mimeType="application/x-sh" />
+            <mimeMap fileExtension=".shar" mimeType="application/x-shar" />
+            <mimeMap fileExtension=".sit" mimeType="application/x-stuffit" />
+            <mimeMap fileExtension=".sldm" mimeType="application/vnd.ms-powerpoint.slide.macroEnabled.12" />
+            <mimeMap fileExtension=".sldx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.slide" />
+            <mimeMap fileExtension=".smd" mimeType="audio/x-smd" />
+            <mimeMap fileExtension=".smi" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".smx" mimeType="audio/x-smd" />
+            <mimeMap fileExtension=".smz" mimeType="audio/x-smd" />
+            <mimeMap fileExtension=".snd" mimeType="audio/basic" />
+            <mimeMap fileExtension=".snp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".spc" mimeType="application/x-pkcs7-certificates" />
+            <mimeMap fileExtension=".spl" mimeType="application/futuresplash" />
+            <mimeMap fileExtension=".spx" mimeType="audio/ogg" />
+            <mimeMap fileExtension=".src" mimeType="application/x-wais-source" />
+            <mimeMap fileExtension=".ssm" mimeType="application/streamingmedia" />
+            <mimeMap fileExtension=".sst" mimeType="application/vnd.ms-pki.certstore" />
+            <mimeMap fileExtension=".stl" mimeType="application/vnd.ms-pki.stl" />
+            <mimeMap fileExtension=".sv4cpio" mimeType="application/x-sv4cpio" />
+            <mimeMap fileExtension=".sv4crc" mimeType="application/x-sv4crc" />
+            <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+            <mimeMap fileExtension=".svgz" mimeType="image/svg+xml" />
+            <mimeMap fileExtension=".swf" mimeType="application/x-shockwave-flash" />
+            <mimeMap fileExtension=".t" mimeType="application/x-troff" />
+            <mimeMap fileExtension=".tar" mimeType="application/x-tar" />
+            <mimeMap fileExtension=".tcl" mimeType="application/x-tcl" />
+            <mimeMap fileExtension=".tex" mimeType="application/x-tex" />
+            <mimeMap fileExtension=".texi" mimeType="application/x-texinfo" />
+            <mimeMap fileExtension=".texinfo" mimeType="application/x-texinfo" />
+            <mimeMap fileExtension=".tgz" mimeType="application/x-compressed" />
+            <mimeMap fileExtension=".thmx" mimeType="application/vnd.ms-officetheme" />
+            <mimeMap fileExtension=".thn" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".tif" mimeType="image/tiff" />
+            <mimeMap fileExtension=".tiff" mimeType="image/tiff" />
+            <mimeMap fileExtension=".toc" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".tr" mimeType="application/x-troff" />
+            <mimeMap fileExtension=".trm" mimeType="application/x-msterminal" />
+            <mimeMap fileExtension=".ts" mimeType="video/vnd.dlna.mpeg-tts" />
+            <mimeMap fileExtension=".tsv" mimeType="text/tab-separated-values" />
+            <mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".tts" mimeType="video/vnd.dlna.mpeg-tts" />
+            <mimeMap fileExtension=".txt" mimeType="text/plain" />
+            <mimeMap fileExtension=".u32" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".uls" mimeType="text/iuls" />
+            <mimeMap fileExtension=".ustar" mimeType="application/x-ustar" />
+            <mimeMap fileExtension=".vbs" mimeType="text/vbscript" />
+            <mimeMap fileExtension=".vcf" mimeType="text/x-vcard" />
+            <mimeMap fileExtension=".vcs" mimeType="text/plain" />
+            <mimeMap fileExtension=".vdx" mimeType="application/vnd.ms-visio.viewer" />
+            <mimeMap fileExtension=".vml" mimeType="text/xml" />
+            <mimeMap fileExtension=".vsd" mimeType="application/vnd.visio" />
+            <mimeMap fileExtension=".vss" mimeType="application/vnd.visio" />
+            <mimeMap fileExtension=".vst" mimeType="application/vnd.visio" />
+            <mimeMap fileExtension=".vsto" mimeType="application/x-ms-vsto" />
+            <mimeMap fileExtension=".vsw" mimeType="application/vnd.visio" />
+            <mimeMap fileExtension=".vsx" mimeType="application/vnd.visio" />
+            <mimeMap fileExtension=".vtx" mimeType="application/vnd.visio" />
+            <mimeMap fileExtension=".wav" mimeType="audio/wav" />
+            <mimeMap fileExtension=".wax" mimeType="audio/x-ms-wax" />
+            <mimeMap fileExtension=".wbmp" mimeType="image/vnd.wap.wbmp" />
+            <mimeMap fileExtension=".wcm" mimeType="application/vnd.ms-works" />
+            <mimeMap fileExtension=".wdb" mimeType="application/vnd.ms-works" />
+            <mimeMap fileExtension=".webm" mimeType="video/webm" />
+            <mimeMap fileExtension=".wks" mimeType="application/vnd.ms-works" />
+            <mimeMap fileExtension=".wm" mimeType="video/x-ms-wm" />
+            <mimeMap fileExtension=".wma" mimeType="audio/x-ms-wma" />
+            <mimeMap fileExtension=".wmd" mimeType="application/x-ms-wmd" />
+            <mimeMap fileExtension=".wmf" mimeType="application/x-msmetafile" />
+            <mimeMap fileExtension=".wml" mimeType="text/vnd.wap.wml" />
+            <mimeMap fileExtension=".wmlc" mimeType="application/vnd.wap.wmlc" />
+            <mimeMap fileExtension=".wmls" mimeType="text/vnd.wap.wmlscript" />
+            <mimeMap fileExtension=".wmlsc" mimeType="application/vnd.wap.wmlscriptc" />
+            <mimeMap fileExtension=".wmp" mimeType="video/x-ms-wmp" />
+            <mimeMap fileExtension=".wmv" mimeType="video/x-ms-wmv" />
+            <mimeMap fileExtension=".wmx" mimeType="video/x-ms-wmx" />
+            <mimeMap fileExtension=".wmz" mimeType="application/x-ms-wmz" />
+            <mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+            <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+            <mimeMap fileExtension=".wps" mimeType="application/vnd.ms-works" />
+            <mimeMap fileExtension=".wri" mimeType="application/x-mswrite" />
+            <mimeMap fileExtension=".wrl" mimeType="x-world/x-vrml" />
+            <mimeMap fileExtension=".wrz" mimeType="x-world/x-vrml" />
+            <mimeMap fileExtension=".wsdl" mimeType="text/xml" />
+            <mimeMap fileExtension=".wtv" mimeType="video/x-ms-wtv" />
+            <mimeMap fileExtension=".wvx" mimeType="video/x-ms-wvx" />
+            <mimeMap fileExtension=".x" mimeType="application/directx" />
+            <mimeMap fileExtension=".xaf" mimeType="x-world/x-vrml" />
+            <mimeMap fileExtension=".xaml" mimeType="application/xaml+xml" />
+            <mimeMap fileExtension=".xap" mimeType="application/x-silverlight-app" />
+            <mimeMap fileExtension=".xbap" mimeType="application/x-ms-xbap" />
+            <mimeMap fileExtension=".xbm" mimeType="image/x-xbitmap" />
+            <mimeMap fileExtension=".xdr" mimeType="text/plain" />
+            <mimeMap fileExtension=".xht" mimeType="application/xhtml+xml" />
+            <mimeMap fileExtension=".xhtml" mimeType="application/xhtml+xml" />
+            <mimeMap fileExtension=".xla" mimeType="application/vnd.ms-excel" />
+            <mimeMap fileExtension=".xlam" mimeType="application/vnd.ms-excel.addin.macroEnabled.12" />
+            <mimeMap fileExtension=".xlc" mimeType="application/vnd.ms-excel" />
+            <mimeMap fileExtension=".xlm" mimeType="application/vnd.ms-excel" />
+            <mimeMap fileExtension=".xls" mimeType="application/vnd.ms-excel" />
+            <mimeMap fileExtension=".xlsb" mimeType="application/vnd.ms-excel.sheet.binary.macroEnabled.12" />
+            <mimeMap fileExtension=".xlsm" mimeType="application/vnd.ms-excel.sheet.macroEnabled.12" />
+            <mimeMap fileExtension=".xlsx" mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+            <mimeMap fileExtension=".xlt" mimeType="application/vnd.ms-excel" />
+            <mimeMap fileExtension=".xltm" mimeType="application/vnd.ms-excel.template.macroEnabled.12" />
+            <mimeMap fileExtension=".xltx" mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.template" />
+            <mimeMap fileExtension=".xlw" mimeType="application/vnd.ms-excel" />
+            <mimeMap fileExtension=".xml" mimeType="text/xml" />
+            <mimeMap fileExtension=".xof" mimeType="x-world/x-vrml" />
+            <mimeMap fileExtension=".xpm" mimeType="image/x-xpixmap" />
+            <mimeMap fileExtension=".xps" mimeType="application/vnd.ms-xpsdocument" />
+            <mimeMap fileExtension=".xsd" mimeType="text/xml" />
+            <mimeMap fileExtension=".xsf" mimeType="text/xml" />
+            <mimeMap fileExtension=".xsl" mimeType="text/xml" />
+            <mimeMap fileExtension=".xslt" mimeType="text/xml" />
+            <mimeMap fileExtension=".xsn" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".xtp" mimeType="application/octet-stream" />
+            <mimeMap fileExtension=".xwd" mimeType="image/x-xwindowdump" />
+            <mimeMap fileExtension=".z" mimeType="application/x-compress" />
+            <mimeMap fileExtension=".zip" mimeType="application/x-zip-compressed" />
+        </staticContent>
+
+        <tracing>
+
+             <traceProviderDefinitions>
+                <add name="WWW Server" guid="{3a2a4e84-4c21-4981-ae10-3fda0d9b0f83}">
+                    <areas>
+                        <clear />
+                        <add name="Authentication" value="2" />
+                        <add name="Security" value="4" />
+                        <add name="Filter" value="8" />
+                        <add name="StaticFile" value="16" />
+                        <add name="CGI" value="32" />
+                        <add name="Compression" value="64" />
+                        <add name="Cache" value="128" />
+                        <add name="RequestNotifications" value="256" />
+                        <add name="Module" value="512" />
+                        <add name="Rewrite" value="1024" />
+                        <add name="FastCGI" value="4096" />
+                        <add name="WebSocket" value="16384" />
+                    </areas>
+                </add>
+                <add name="ASP" guid="{06b94d9a-b15e-456e-a4ef-37c984a2cb4b}">
+                    <areas>
+                        <clear />
+                    </areas>
+                </add>
+                <add name="ISAPI Extension" guid="{a1c2040e-8840-4c31-ba11-9871031a19ea}">
+                    <areas>
+                        <clear />
+                    </areas>
+                </add>
+                <add name="ASPNET" guid="{AFF081FE-0247-4275-9C4E-021F3DC1DA35}">
+                    <areas>
+                        <add name="Infrastructure" value="1" />
+                        <add name="Module" value="2" />
+                        <add name="Page" value="4" />
+                        <add name="AppServices" value="8" />
+                    </areas>
+                </add>
+            </traceProviderDefinitions>
+
+            <traceFailedRequests>
+                <add path="*">
+                    <traceAreas>
+                        <add provider="ASP" verbosity="Verbose" />
+                        <add provider="ASPNET" areas="Infrastructure,Module,Page,AppServices" verbosity="Verbose" />
+                        <add provider="ISAPI Extension" verbosity="Verbose" />
+                        <add provider="WWW Server" areas="Authentication,Security,Filter,StaticFile,CGI,Compression,Cache,RequestNotifications,Module,Rewrite,WebSocket" verbosity="Verbose" />
+                    </traceAreas>
+                    <failureDefinitions statusCodes="200-999" />
+                </add>
+            </traceFailedRequests>
+
+        </tracing>
+
+        <urlCompression />
+
+        <validation />
+        <webdav>
+            <globalSettings>
+                <propertyStores>
+                    <add name="webdav_simple_prop" image="%IIS_BIN%\webdav_simple_prop.dll" image32="%IIS_BIN%\webdav_simple_prop.dll" />
+                </propertyStores>
+                <lockStores>
+                    <add name="webdav_simple_lock" image="%IIS_BIN%\webdav_simple_lock.dll" image32="%IIS_BIN%\webdav_simple_lock.dll" />
+                </lockStores>
+
+            </globalSettings>
+            <authoring>
+                <locks enabled="true" lockStore="webdav_simple_lock" />
+            </authoring>
+            <authoringRules />
+        </webdav>
+        <webSocket />
+        <applicationInitialization />
+
+    </system.webServer>
+    <location path="" overrideMode="Allow">
+        <system.webServer>
+            <modules>
+                <add name="IsapiFilterModule" lockItem="true" />
+                <add name="BasicAuthenticationModule" lockItem="true" />
+                <add name="IsapiModule" lockItem="true" />
+                <add name="HttpLoggingModule" lockItem="true" />
+                <!--
+                <add name="HttpCacheModule" lockItem="true" />
+-->
+                <add name="DynamicCompressionModule" lockItem="true" />
+                <add name="StaticCompressionModule" lockItem="true" />
+                <add name="DefaultDocumentModule" lockItem="true" />
+                <add name="DirectoryListingModule" lockItem="true" />
+
+                <add name="ProtocolSupportModule" lockItem="true" />
+                <add name="HttpRedirectionModule" lockItem="true" />
+                <add name="ServerSideIncludeModule" lockItem="true" />
+                <add name="StaticFileModule" lockItem="true" />
+                <add name="AnonymousAuthenticationModule" lockItem="true" />
+                <add name="CertificateMappingAuthenticationModule" lockItem="true" />
+                <add name="UrlAuthorizationModule" lockItem="true" />
+                <add name="WindowsAuthenticationModule" lockItem="true" />
+                <!--
+                <add name="DigestAuthenticationModule" lockItem="true" />
+-->
+                <add name="IISCertificateMappingAuthenticationModule" lockItem="true" />
+                <add name="WebMatrixSupportModule" lockItem="true" />
+                <add name="IpRestrictionModule" lockItem="true" />
+                <add name="DynamicIpRestrictionModule" lockItem="true" />
+                <add name="RequestFilteringModule" lockItem="true" />
+                <add name="CustomLoggingModule" lockItem="true" />
+                <add name="CustomErrorModule" lockItem="true" />
+                <add name="FailedRequestsTracingModule" lockItem="true" />
+                <add name="CgiModule" lockItem="true" />
+                <add name="FastCgiModule" lockItem="true" />
+                <!--                <add name="WebDAVModule" /> -->
+                <add name="RewriteModule" />
+                <add name="OutputCache" type="System.Web.Caching.OutputCacheModule" preCondition="managedHandler" />
+                <add name="Session" type="System.Web.SessionState.SessionStateModule" preCondition="managedHandler" />
+                <add name="WindowsAuthentication" type="System.Web.Security.WindowsAuthenticationModule" preCondition="managedHandler" />
+                <add name="FormsAuthentication" type="System.Web.Security.FormsAuthenticationModule" preCondition="managedHandler" />
+                <add name="DefaultAuthentication" type="System.Web.Security.DefaultAuthenticationModule" preCondition="managedHandler" />
+                <add name="RoleManager" type="System.Web.Security.RoleManagerModule" preCondition="managedHandler" />
+                <add name="UrlAuthorization" type="System.Web.Security.UrlAuthorizationModule" preCondition="managedHandler" />
+                <add name="FileAuthorization" type="System.Web.Security.FileAuthorizationModule" preCondition="managedHandler" />
+                <add name="AnonymousIdentification" type="System.Web.Security.AnonymousIdentificationModule" preCondition="managedHandler" />
+                <add name="Profile" type="System.Web.Profile.ProfileModule" preCondition="managedHandler" />
+                <add name="UrlMappingsModule" type="System.Web.UrlMappingsModule" preCondition="managedHandler" />
+                <add name="ConfigurationValidationModule" lockItem="true" />
+                <add name="WebSocketModule" lockItem="true" />
+                <add name="ServiceModel-4.0" type="System.ServiceModel.Activation.ServiceHttpModule,System.ServiceModel.Activation,Version=4.0.0.0,Culture=neutral,PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
+                <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler,runtimeVersionv4.0" />
+                <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
+                <add name="ServiceModel" type="System.ServiceModel.Activation.HttpModule, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="managedHandler,runtimeVersionv2.0" />
+                <add name="ApplicationInitializationModule" lockItem="true" />
+            </modules>
+            <handlers accessPolicy="Read, Script">
+                <!--                <add name="WebDAV" path="*" verb="PROPFIND,PROPPATCH,MKCOL,PUT,COPY,DELETE,MOVE,LOCK,UNLOCK" modules="WebDAVModule" resourceType="Unspecified" requireAccess="None" /> -->
+                <add name="AXD-ISAPI-4.0_64bit" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="PageHandlerFactory-ISAPI-4.0_64bit" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="SimpleHandlerFactory-ISAPI-4.0_64bit" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="WebServiceHandlerFactory-ISAPI-4.0_64bit" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-rem-ISAPI-4.0_64bit" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-soap-ISAPI-4.0_64bit" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="svc-ISAPI-4.0_64bit" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+                <add name="rules-ISAPI-4.0_64bit" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+                <add name="xoml-ISAPI-4.0_64bit" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+                <add name="xamlx-ISAPI-4.0_64bit" path="*.xamlx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+                <add name="aspq-ISAPI-4.0_64bit" path="*.aspq" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="cshtm-ISAPI-4.0_64bit" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="cshtml-ISAPI-4.0_64bit" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="vbhtm-ISAPI-4.0_64bit" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="vbhtml-ISAPI-4.0_64bit" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="svc-Integrated" path="*.svc" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="svc-ISAPI-2.0" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+                <add name="xoml-Integrated" path="*.xoml" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="xoml-ISAPI-2.0" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+                <add name="rules-Integrated" path="*.rules" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="rules-ISAPI-2.0" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+                <add name="AXD-ISAPI-4.0_32bit" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="PageHandlerFactory-ISAPI-4.0_32bit" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="SimpleHandlerFactory-ISAPI-4.0_32bit" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="WebServiceHandlerFactory-ISAPI-4.0_32bit" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-rem-ISAPI-4.0_32bit" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-soap-ISAPI-4.0_32bit" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="svc-ISAPI-4.0_32bit" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+                <add name="rules-ISAPI-4.0_32bit" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+                <add name="xoml-ISAPI-4.0_32bit" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+                <add name="xamlx-ISAPI-4.0_32bit" path="*.xamlx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+                <add name="aspq-ISAPI-4.0_32bit" path="*.aspq" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="cshtm-ISAPI-4.0_32bit" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="cshtml-ISAPI-4.0_32bit" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="vbhtm-ISAPI-4.0_32bit" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="vbhtml-ISAPI-4.0_32bit" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="TraceHandler-Integrated-4.0" path="trace.axd" verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TraceHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="WebAdminHandler-Integrated-4.0" path="WebAdmin.axd" verb="GET,DEBUG" type="System.Web.Handlers.WebAdminHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="AssemblyResourceLoader-Integrated-4.0" path="WebResource.axd" verb="GET,DEBUG" type="System.Web.Handlers.AssemblyResourceLoader" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="PageHandlerFactory-Integrated-4.0" path="*.aspx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.PageHandlerFactory" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="SimpleHandlerFactory-Integrated-4.0" path="*.ashx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.SimpleHandlerFactory" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="WebServiceHandlerFactory-Integrated-4.0" path="*.asmx" verb="GET,HEAD,POST,DEBUG" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="HttpRemotingHandlerFactory-rem-Integrated-4.0" path="*.rem" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="HttpRemotingHandlerFactory-soap-Integrated-4.0" path="*.soap" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="svc-Integrated-4.0" path="*.svc" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="rules-Integrated-4.0" path="*.rules" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="xoml-Integrated-4.0" path="*.xoml" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="xamlx-Integrated-4.0" path="*.xamlx" verb="GET,HEAD,POST,DEBUG" type="System.Xaml.Hosting.XamlHttpHandlerFactory, System.Xaml.Hosting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="aspq-Integrated-4.0" path="*.aspq" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="cshtm-Integrated-4.0" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="cshtml-Integrated-4.0" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="vbhtm-Integrated-4.0" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="vbhtml-Integrated-4.0" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="ScriptHandlerFactoryAppServices-Integrated-4.0" path="*_AppService.axd" verb="*" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="ScriptResourceIntegrated-4.0" path="*ScriptResource.axd" verb="GET,HEAD" type="System.Web.Handlers.ScriptResourceHandler, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" preCondition="integratedMode,runtimeVersionv4.0" />
+                <add name="ASPClassic" path="*.asp" verb="GET,HEAD,POST" modules="IsapiModule" scriptProcessor="%IIS_BIN%\asp.dll" resourceType="File" />
+                <add name="SecurityCertificate" path="*.cer" verb="GET,HEAD,POST" modules="IsapiModule" scriptProcessor="%IIS_BIN%\asp.dll" resourceType="File" />
+                <add name="ISAPI-dll" path="*.dll" verb="*" modules="IsapiModule" resourceType="File" requireAccess="Execute" allowPathInfo="true" />
+                <add name="TraceHandler-Integrated" path="trace.axd" verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TraceHandler" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="WebAdminHandler-Integrated" path="WebAdmin.axd" verb="GET,DEBUG" type="System.Web.Handlers.WebAdminHandler" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="AssemblyResourceLoader-Integrated" path="WebResource.axd" verb="GET,DEBUG" type="System.Web.Handlers.AssemblyResourceLoader" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="PageHandlerFactory-Integrated" path="*.aspx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.PageHandlerFactory" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="SimpleHandlerFactory-Integrated" path="*.ashx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.SimpleHandlerFactory" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="WebServiceHandlerFactory-Integrated" path="*.asmx" verb="GET,HEAD,POST,DEBUG" type="System.Web.Services.Protocols.WebServiceHandlerFactory,System.Web.Services,Version=2.0.0.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="HttpRemotingHandlerFactory-rem-Integrated" path="*.rem" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory,System.Runtime.Remoting,Version=2.0.0.0,Culture=neutral,PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="HttpRemotingHandlerFactory-soap-Integrated" path="*.soap" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory,System.Runtime.Remoting,Version=2.0.0.0,Culture=neutral,PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+                <add name="AXD-ISAPI-2.0" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+                <add name="PageHandlerFactory-ISAPI-2.0" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+                <add name="SimpleHandlerFactory-ISAPI-2.0" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+                <add name="WebServiceHandlerFactory-ISAPI-2.0" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-rem-ISAPI-2.0" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-soap-ISAPI-2.0" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+                <add name="svc-ISAPI-2.0-64" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+                <add name="AXD-ISAPI-2.0-64" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+                <add name="PageHandlerFactory-ISAPI-2.0-64" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+                <add name="SimpleHandlerFactory-ISAPI-2.0-64" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+                <add name="WebServiceHandlerFactory-ISAPI-2.0-64" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-rem-ISAPI-2.0-64" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+                <add name="HttpRemotingHandlerFactory-soap-ISAPI-2.0-64" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+                <add name="rules-64-ISAPI-2.0" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+                <add name="xoml-64-ISAPI-2.0" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+                <add name="CGI-exe" path="*.exe" verb="*" modules="CgiModule" resourceType="File" requireAccess="Execute" allowPathInfo="true" />
+                <add name="SSINC-stm" path="*.stm" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+                <add name="SSINC-shtm" path="*.shtm" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+                <add name="SSINC-shtml" path="*.shtml" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+                <add name="TRACEVerbHandler" path="*" verb="TRACE" modules="ProtocolSupportModule" requireAccess="None" />
+                <add name="OPTIONSVerbHandler" path="*" verb="OPTIONS" modules="ProtocolSupportModule" requireAccess="None" />
+                <add name="ExtensionlessUrl-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+                <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+                <add name="ExtensionlessUrl-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" responseBufferLimit="0" />
+                <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
+            </handlers>
+        </system.webServer>
+    </location>
+</configuration>

--- a/src/Feature/Sitemap/code/App_Config/Include/Feature/Feature.Sitemap.Serialization.config
+++ b/src/Feature/Sitemap/code/App_Config/Include/Feature/Feature.Sitemap.Serialization.config
@@ -1,0 +1,17 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+	<sitecore>
+		<unicorn>
+			<configurations>
+				<configuration name="Feature.Sitemap" description="Feature Sitemap" dependencies="Foundation.Serialization,Foundation.Indexing" patch:after="configuration[@name='Foundation.Serialization']">
+					<targetDataStore physicalRootPath="$(sourceFolder)\feature\Sitemap\serialization" type="Rainbow.Storage.SerializationFileSystemDataStore, Rainbow" useDataCache="false" singleInstance="true" />
+					<predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
+						<include name="Feature.Sitemap.Templates" database="master" path="/sitecore/templates/Feature/Sitemap" />
+						<include name="Feature.Sitemap.System" database="master" path="/sitecore/system/Modules/Sitemap" />
+						<include name="Feature.Sitemap.system.Tasks.Commands" database="master" path="/sitecore/system/Tasks/Commands/Sitemap XML" />
+						<include name="Feature.Sitemap.system.Tasks.Schedules" database="master" path="/sitecore/system/Tasks/Schedules/Sitemap XML" />
+					</predicate>
+				</configuration>
+			</configurations>
+		</unicorn>
+	</sitecore>
+</configuration>

--- a/src/Feature/Sitemap/code/App_Config/Include/SitemapXML.config
+++ b/src/Feature/Sitemap/code/App_Config/Include/SitemapXML.config
@@ -1,0 +1,80 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+  <sitecore>
+    <events timingLevel="custom">
+      <event name="publish:end">
+        <handler type="Sitecore.Feature.Sitemap.SitemapManager.SitemapHandler, Sitecore.Feature.Sitemap" method="RefreshSitemap" />
+      </event>
+    </events>
+    <sitemapVariables>
+      <sitemapVariable name="xmlnsTpl" value="http://www.sitemaps.org/schemas/sitemap/0.9" />
+      <sitemapVariable name="database" value="web" />
+      <sitemapVariable name="sitemapConfigurationItemPath" value="/sitecore/system/Modules/Sitemap/Sitemap Configuration" />
+      <sitemapVariable name="sitemapIndexFilename" value="sitemap.xml" />
+      <sitemapVariable name="indexName" value="sitemap_web" />
+     
+    </sitemapVariables>
+    <linkManager>
+      <providers>
+        <add name="sitecore">
+          <patch:attribute name="addAspxExtension">false</patch:attribute>
+          <patch:attribute name="languageEmbedding">never</patch:attribute>
+        </add>
+      </providers>
+    </linkManager>
+    <!--For SEO purpose, we might want to replace space in url with hyphen.
+    Remove below encodeNameReplacements if we do not want to do so.
+    Note that if we replace space with hyphen in url then content item name should not have hyphen.
+    We can do so by either adjust InvalidItemNameChars settings (as below) or writing Item Name rule not to allow hyphen for item name if the item is content item.-->
+    <encodeNameReplacements>
+      <replace mode="on" find=" " replaceWith="-" />
+    </encodeNameReplacements>
+
+    <!--Index for content items-->
+    <contentSearch>
+      <configuration type="Sitecore.ContentSearch.ContentSearchConfiguration, Sitecore.ContentSearch">
+        <indexes hint="list:AddIndex">
+          <index id="sitemap_web" type="Sitecore.ContentSearch.LuceneProvider.LuceneIndex, Sitecore.ContentSearch.LuceneProvider">
+            <param desc="name">$(id)</param>
+            <param desc="folder">$(id)</param>
+            <!-- This initializes index property store. Id has to be set to the index id -->
+            <param desc="propertyStore" ref="contentSearch/indexConfigurations/databasePropertyStore" param1="$(id)" />
+            <configuration ref="contentSearch/indexConfigurations/defaultLuceneIndexConfiguration" />
+            <strategies hint="list:AddStrategy">
+              <!-- NOTE: order of these is controls the execution order -->
+              <strategy ref="contentSearch/indexConfigurations/indexUpdateStrategies/onPublishEndAsync" />
+            </strategies>
+            <commitPolicyExecutor type="Sitecore.ContentSearch.CommitPolicyExecutor, Sitecore.ContentSearch">
+              <policies hint="list:AddCommitPolicy">
+                <policy type="Sitecore.ContentSearch.ModificationCountCommitPolicy, Sitecore.ContentSearch">
+                  <Limit>300</Limit>
+                </policy>
+              </policies>
+            </commitPolicyExecutor>
+            <locations hint="list:AddCrawler">
+              <crawler type="Sitecore.ContentSearch.SitecoreItemCrawler, Sitecore.ContentSearch">
+                <Database>web</Database>
+                <Root>/sitecore/content</Root>
+              </crawler>
+            </locations>
+            <enableItemLanguageFallback>false</enableItemLanguageFallback>
+            <enableFieldLanguageFallback>false</enableFieldLanguageFallback>
+            <!--
+            <shardingStrategy type="Sitecore.ContentSearch.LuceneProvider.Sharding.LucenePartitionShardingStrategy, Sitecore.ContentSearch.LuceneProvider">
+              <param desc="shardDistribution">4</param>
+            </shardingStrategy>
+            -->
+
+            <!--
+            <shardFolders hint="raw:AddShardFolderPath">
+              <shard shardName="shard1" shardRootFolderPath="c:\Data\Indexes" />
+              <shard shardName="shard2" shardRootFolderPath="c:\Data\Indexes" />
+              <shard shardName="shard3" shardRootFolderPath="c:\Data\Indexes" />
+            </shardFolders>
+            -->
+          </index>
+        </indexes>
+      </configuration>
+    </contentSearch>
+
+  </sitecore>
+</configuration>

--- a/src/Feature/Sitemap/code/Configuration/SitemapManagerConfiguration.cs
+++ b/src/Feature/Sitemap/code/Configuration/SitemapManagerConfiguration.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Xml;
+using Sitecore.Configuration;
+using Sitecore.Data;
+using Sitecore.Data.Items;
+using Sitecore.Xml;
+
+namespace Sitecore.Feature.Sitemap.Configuration 
+{
+    public class SitemapManagerConfiguration
+    {
+        #region properties
+
+
+
+        public static string XmlnsTpl
+        {
+            get
+            {
+                return GetValueByName("xmlnsTpl");
+            }
+        }
+
+
+
+        public static string WorkingDatabase
+        {
+            get
+            {
+                return GetValueByName("database");
+            }
+        }
+        
+        public static string SitemapConfigurationItemPath
+        {
+            get
+            {
+                return GetValueByName("sitemapConfigurationItemPath");
+            }
+        }
+
+      
+        public static bool IsProductionEnvironment
+        {
+            get
+            {
+                string production = GetValueByNameFromDatabase(Templates.SitemapXMLSettings.Fields.IsProduction.ToString());
+                return !string.IsNullOrEmpty(production) && (production.ToLower() == "true" || production == "1");
+            }
+        }
+
+       
+        public static string SitemapIndexFilename
+        {
+            get
+            {
+                return GetValueByName("sitemapIndexFilename");
+            }
+        }
+
+        public static string IndexName
+        {
+            get
+            {
+                return GetValueByName("indexName");
+            }
+        }
+        #endregion properties
+
+        private static string GetValueByName(string name)
+        {
+            string result = string.Empty;
+
+            foreach (XmlNode node in Factory.GetConfigNodes("sitemapVariables/sitemapVariable"))
+            {
+
+                if (XmlUtil.GetAttribute("name", node) == name)
+                {
+                    result = XmlUtil.GetAttribute("value", node);
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        private static string GetValueByNameFromDatabase(string name)
+        {
+            string result = string.Empty;
+
+            Database db = Factory.GetDatabase(WorkingDatabase);
+            if (db != null)
+            {
+                Item configItem = db.Items[SitemapConfigurationItemPath];
+                if (configItem != null)
+                {
+                    result = configItem[name];
+                }
+            }
+
+            return result;
+        }
+
+        public static List<Item> GetSiteItems()
+        {
+            List<Item> siteItemList = new List<Item>();
+            string siteField = GetValueByNameFromDatabase(Templates.SitemapSelector.Fields.Sites.ToString());
+            if(!string.IsNullOrEmpty(siteField))
+            {
+                var siteItems = siteField.Split('|');
+                if(siteItems!=null)
+                {
+                    Database db = Factory.GetDatabase(WorkingDatabase);
+                    foreach (string site in siteItems)
+                    {
+                        siteItemList.Add(db.GetItem(site));
+                    }
+                }
+            }
+            return siteItemList;
+        }
+
+        public static StringDictionary GetSites()
+        {
+            StringDictionary sites = new StringDictionary();
+            var siteItems = GetSiteItems();
+            if(siteItems.Any())
+            {
+                foreach(Item itm in siteItems)
+                {
+                    if(!string.IsNullOrEmpty(itm[Templates.Sites.Fields.SiteName]) && !string.IsNullOrEmpty(itm[Templates.Sites.Fields.FileName]))
+                    {
+                        sites.Add(itm[Templates.Sites.Fields.SiteName], itm[Templates.Sites.Fields.FileName]);
+                    }
+                }
+
+            }
+            return sites;
+        }
+
+        public static string GetServerUrlBySite(string name)
+        {
+            string result = string.Empty;
+            var siteItems = GetSiteItems();
+            if (siteItems.Any())
+            {
+                Item itm = siteItems.Where(i=>i[Templates.Sites.Fields.SiteName].ToLower()==name.ToLower()).FirstOrDefault();
+                if(itm !=null && !string.IsNullOrEmpty(itm[Templates.Sites.Fields.ServerURL]))
+                {
+                    result = itm[Templates.Sites.Fields.ServerURL];
+                }
+                
+            }
+            return result;
+        }
+    }
+}

--- a/src/Feature/Sitemap/code/Controllers/SitemapController.cs
+++ b/src/Feature/Sitemap/code/Controllers/SitemapController.cs
@@ -1,0 +1,59 @@
+﻿using System.Web.Mvc;
+using Sitecore.Data.Items;
+using Sitecore.Feature.Sitemap.Repositories;
+using Sitecore.Mvc.Presentation;
+
+namespace Sitecore.Feature.Sitemap.Controllers
+{
+    public class SitemapController : Controller
+    {
+        private readonly ISitemapRepositories _sitemapRepository;
+        public SitemapController() : this(new SitemapRepositories(getRenderingItem()))
+        {
+        }
+
+        public static Item getRenderingItem()
+        {
+            if (System.Web.HttpContext.Current.Request.Params["datasource"] != null)
+            {
+                return null;
+            }
+            else if (System.Web.HttpContext.Current.Request.QueryString["DS"] == null)
+            {
+                return RenderingContext.Current.Rendering.Item;
+            }
+            else
+            {
+                var queryString = System.Web.HttpContext.Current.Request.QueryString["DS"];
+                return Sitecore.Context.Database.GetItem(queryString);
+            }
+        }
+
+        public SitemapController(ISitemapRepositories sitemapRepository)
+        {
+            this._sitemapRepository = sitemapRepository;
+        }
+        public ActionResult Sitemap()
+        {
+            var items = _sitemapRepository.GetSitemapItems(Sitecore.Context.Item);
+            return this.View("Sitemap",items);
+        }
+
+        [HttpGet]
+        public ActionResult SitemapWithExpend()
+        {
+
+            var items = _sitemapRepository.GetSitemapItems(Sitecore.Context.Item);
+            return this.View("SitemapWithExpend", items);
+        }
+        [HttpPost]
+        public ActionResult SitemapWithExpend(string itemID)
+        {
+
+
+            var currentItem = Sitecore.Context.Database.GetItem(itemID);
+            var items = _sitemapRepository.GetSitemapItemsForAjax(currentItem);
+            return this.View("_SitemapWithExpend", items);
+        }
+    }
+}

--- a/src/Feature/Sitemap/code/Models/SitemapItem.cs
+++ b/src/Feature/Sitemap/code/Models/SitemapItem.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Sitecore.Data.Items;
+
+namespace Sitecore.Feature.Sitemap.Models.Sitemap
+{
+    public class SitemapItem
+    {
+        public Item Item { get; set; }
+        public string Url { get; set; }
+        public int Level { get; set; }
+        public IList<SitemapItem> Children { get; set; }
+        public SitemapItems ChildItems { get; set; }
+    }
+}

--- a/src/Feature/Sitemap/code/Models/SitemapItems.cs
+++ b/src/Feature/Sitemap/code/Models/SitemapItems.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Sitecore.Mvc.Presentation;
+using System.Linq;
+using System.Web;
+
+namespace Sitecore.Feature.Sitemap.Models.Sitemap
+{
+    using Sitecore.Data.Items;
+    public class SitemapItems : RenderingModel
+    {   
+        public IList<SitemapItem> Items { get; set; }
+
+        public SitemapItem CurrentItem { get; set; }
+    }
+}

--- a/src/Feature/Sitemap/code/Models/Web.config
+++ b/src/Feature/Sitemap/code/Models/Web.config
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0"?>
+
+<configuration>
+  <configSections>
+    <sectionGroup name="system.web.webPages.razor"
+                  type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host"
+               type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+               requirePermission="false" />
+      <section name="pages"
+               type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+               requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+
+  <system.web.webPages.razor>
+    <host
+      factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <pages pageBaseType="System.Web.Mvc.WebViewPage">
+      <namespaces>
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Optimization" />
+        <add namespace="System.Web.Routing" />
+        <add namespace="Sitecore.Mvc" />
+      </namespaces>
+    </pages>
+  </system.web.webPages.razor>
+
+  <appSettings>
+    <add key="webpages:Enabled" value="false" />
+  </appSettings>
+
+  <system.webServer>
+    <handlers>
+      <remove name="BlockViewHandler" />
+      <add name="BlockViewHandler" path="*.cshtml" verb="*" preCondition="integratedMode"
+           type="System.Web.HttpNotFoundHandler" />
+    </handlers>
+  </system.webServer>
+</configuration>

--- a/src/Feature/Sitemap/code/Properties/AssemblyInfo.cs
+++ b/src/Feature/Sitemap/code/Properties/AssemblyInfo.cs
@@ -1,0 +1,38 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("Sitecore.Feature.PageContent")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sitecore.Feature.PageContent")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("da079e95-db53-4a66-ab35-2dab71d19276")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Feature/Sitemap/code/Properties/PublishProfiles/Local.pubxml
+++ b/src/Feature/Sitemap/code/Properties/PublishProfiles/Local.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\..\..\publishsettings.targets" />
+
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/src/Feature/Sitemap/code/Repositories/ISitemapRepositories.cs
+++ b/src/Feature/Sitemap/code/Repositories/ISitemapRepositories.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sitecore.Feature.Sitemap.Repositories
+{
+    using Data.Items;
+    using Sitecore.Feature.Sitemap.Models.Sitemap;
+    
+    public interface ISitemapRepositories
+    {
+        Item GetSiteRoot(Item contextItem);
+        SitemapItems GetSitemapItems(Item contextItem);
+
+        SitemapItems GetSitemapItemsForAjax(Item contextItem);
+
+    }
+}

--- a/src/Feature/Sitemap/code/Repositories/SitemapRepositories.cs
+++ b/src/Feature/Sitemap/code/Repositories/SitemapRepositories.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Sitecore.Data.Items;
+using Sitecore.Feature.Sitemap.Models.Sitemap;
+using Sitecore.Foundation.SitecoreExtensions.Extensions;
+using Sitecore.Data.Fields;
+using Sitecore.ContentSearch;
+
+
+namespace Sitecore.Feature.Sitemap.Repositories
+{
+    public class SitemapRepositories:ISitemapRepositories
+    { 
+        public Item ContextItem { get; }
+        public Item SiteRoot { get;}
+        public SitemapRepositories(Item contextItem)
+        {
+            this.ContextItem = contextItem;
+            this.SiteRoot = this.GetSiteRoot(this.ContextItem);
+        }
+        public Item GetSiteRoot(Item contextItem)
+        {
+            return Sitecore.Context.Database.GetItem(Sitecore.Context.Site.StartPath);
+          
+        }
+        
+        public SitemapItems GetSitemapItems(Item contextItem)
+        {
+            var siteItems = this.ChildSitemapItems(this.SiteRoot, 0, 1);
+            return siteItems;
+        }
+
+
+        public SitemapItems GetSitemapItemsForAjax(Item contextItem)
+        {
+            var siteItems = this.ChildSitemapItems(contextItem, 0, 1);
+            return siteItems;
+        }
+
+        private void AddRootToSitemap(SitemapItems siteItems)
+        {
+            if (!this.IncludeInSitemap(this.SiteRoot))
+            {
+                return;
+            }
+        }
+        
+        private SitemapItem CreateSitemapItem(Item item, int level, int maxLevel = -1)
+        {
+            return new SitemapItem
+            {
+                Item = item,
+                Url = item.Url(),
+                ChildItems = this.ChildSitemapItems(item, level + 1, maxLevel)
+
+            };
+        }
+       
+        private SitemapItems ChildSitemapItems(Item parentItem, int level, int maxLevel)
+        {
+
+            if (!parentItem.HasChildren)
+            {
+                return null;
+            }
+
+            var childItems = parentItem.Children.Where(i => i.Versions.Count != 0).Where(item => IncludeInSitemap(item)).Select(i => this.CreateSitemapItem(i, level, maxLevel));
+            return new SitemapItems
+            {
+                Items = childItems.ToList()
+            };
+        }
+
+        private bool IncludeInSitemap(Item item)
+        {
+            return item.IsDerived(Templates.Sitemap.ID) && (MainUtil.GetBool(item[Templates.Sitemap.Fields.IncludeInSitemap], false));
+        }
+    }
+}

--- a/src/Feature/Sitemap/code/Sitecore.Feature.Sitemap.csproj
+++ b/src/Feature/Sitemap/code/Sitecore.Feature.Sitemap.csproj
@@ -1,0 +1,202 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{1C81158C-96BD-4D0B-877C-651C1143D19E}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sitecore.Feature.Sitemap</RootNamespace>
+    <AssemblyName>Sitecore.Feature.Sitemap</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <UseGlobalApplicationHostFile />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>bin\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ContentSearch.NoReferences.8.2.161115\lib\NET452\Sitecore.ContentSearch.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.Linq, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Websites\sitecoreDemo\Website\bin\Sitecore.ContentSearch.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.8.2.161115\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.NoReferences.8.2.161115\lib\NET452\Sitecore.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+    <Content Include="App_Config\Include\Feature\Feature.Sitemap.Serialization.config" />
+    <Content Include="App_Config\Include\SitemapXML.config">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Models\Web.config" />
+    <None Include="Properties\PublishProfiles\Local.pubxml" />
+    <Content Include="Views\Sitemap\Sitemap.cshtml" />
+    <Content Include="Views\Web.config" />
+    <Content Include="Views\Sitemap\SitemapWithExpend.cshtml" />
+    <Content Include="Views\Sitemap\_SitemapWithExpend.cshtml" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Configuration\SitemapManagerConfiguration.cs" />
+    <Compile Include="Controllers\SitemapController.cs" />
+    <Compile Include="Models\SitemapItem.cs" />
+    <Compile Include="Models\SitemapItems.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Repositories\ISitemapRepositories.cs" />
+    <Compile Include="Repositories\SitemapRepositories.cs" />
+    <Compile Include="SitemapManager\SitemapHandler.cs" />
+    <Compile Include="SitemapManager\SitemapManager.cs" />
+    <Compile Include="Templates.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Foundation\Alerts\code\Sitecore.Foundation.Alerts.csproj">
+      <Project>{5CF5FA06-AB27-4DF5-A471-ED57EF3E4AE9}</Project>
+      <Name>Sitecore.Foundation.Alerts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Foundation\Dictionary\code\Sitecore.Foundation.Dictionary.csproj">
+      <Project>{0D6BA4D8-C469-4AE9-9EBB-93BDF7D7E78F}</Project>
+      <Name>Sitecore.Foundation.Dictionary</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\foundation\Indexing\code\Sitecore.Foundation.Indexing.csproj">
+      <Project>{80213F24-577F-4F0B-A3B8-62485EA4D2F3}</Project>
+      <Name>Sitecore.Foundation.Indexing</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\foundation\SitecoreExtensions\code\Sitecore.Foundation.SitecoreExtensions.csproj">
+      <Project>{b535703f-8d07-4f23-a533-2974bb4cc7b1}</Project>
+      <Name>Sitecore.Foundation.SitecoreExtensions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>False</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>59548</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:59548/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Feature/Sitemap/code/SitemapManager/SitemapHandler.cs
+++ b/src/Feature/Sitemap/code/SitemapManager/SitemapHandler.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sitecore.Configuration;
+using Sitecore.Data;
+using Sitecore.Data.Items;
+using Sitecore.ContentSearch;
+using Sitecore.Feature.Sitemap.Configuration;
+using log4net;
+
+namespace Sitecore.Feature.Sitemap.SitemapManager
+{
+    public class SitemapHandler
+    {
+        private ILog log = LogManager.GetLogger("Sitemap XML");
+        public void RefreshSitemap(object sender, EventArgs args)
+        {
+            try
+            {
+                Database db = Factory.GetDatabase(SitemapManagerConfiguration.WorkingDatabase);
+                Item sitemapConfig = db.Items[SitemapManagerConfiguration.SitemapConfigurationItemPath];
+                if (sitemapConfig != null && sitemapConfig[Templates.SitemapXMLSettings.Fields.GenerateSitempXML] == "1" && sitemapConfig[Templates.SitemapXMLSettings.Fields.GenerateSitempXMLOnPublishing] == "1")
+                {
+                    SitemapManager sitemapManager = new SitemapManager();
+                    sitemapManager.SubmitSitemapToSearchenginesByHttp();
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error("Sitemap is null" + ex.ToString());
+            }
+        }
+        
+        public void Execute(Item[] items, Sitecore.Tasks.CommandItem command, Sitecore.Tasks.ScheduleItem schedule)
+        {
+            try
+            {
+                Database db = Factory.GetDatabase(SitemapManagerConfiguration.WorkingDatabase);
+                if (db != null)
+                {
+                    Item sitemapConfig = db.Items[SitemapManagerConfiguration.SitemapConfigurationItemPath];
+                    if (sitemapConfig != null && sitemapConfig[Templates.SitemapXMLSettings.Fields.GenerateSitempXML] == "1" && sitemapConfig[Templates.SitemapXMLSettings.Fields.GenerateSitemapXMLByScheduler] == "1")
+                    {  
+                        SitemapManager sitemapManager = new SitemapManager();
+                        sitemapManager.SubmitSitemapToSearchenginesByHttp();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error("Sitemap is null" + ex.ToString());
+            }
+        }
+    }
+}

--- a/src/Feature/Sitemap/code/SitemapManager/SitemapManager.cs
+++ b/src/Feature/Sitemap/code/SitemapManager/SitemapManager.cs
@@ -1,0 +1,439 @@
+﻿namespace Sitecore.Feature.Sitemap.SitemapManager
+{
+    using Sitecore;
+    using Sitecore.Configuration;
+    using Sitecore.Data;
+    using Sitecore.Data.Items;
+    using Sitecore.Diagnostics;
+    using Sitecore.Sites;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Web;
+    using System.Xml;
+    using Sitecore.Foundation.SitecoreExtensions.Extensions;
+    using System.Globalization;
+    using Collections;
+    using Sitecore.ContentSearch;
+    using Sitecore.ContentSearch.SearchTypes;
+    using Sitecore.ContentSearch.Utilities;
+    using Data.Managers;
+    using Globalization;
+    using Links;
+    using log4net;
+    using Sitecore.Feature.Sitemap.Configuration;
+
+    public class SitemapManager
+    {
+        private ILog log = LogManager.GetLogger("Sitemap XML");
+        private Database _db = null;
+        private static System.Collections.Specialized.StringDictionary m_Sites;
+        public Database Db
+        {
+            get
+            {
+                if (_db == null)
+                {
+                    _db = Factory.GetDatabase(SitemapManagerConfiguration.WorkingDatabase);
+                }
+
+                return _db;
+            }
+        }
+
+        private DeviceItem _defaultDevice = null;
+        private DeviceItem DefaultDevice
+        {
+            get
+            {
+                if (_defaultDevice == null)
+                {
+                    _defaultDevice = Db.Resources.Devices.GetAll().Where(i => i.IsDefault).FirstOrDefault();
+                }
+
+                return _defaultDevice;
+            }
+        }
+
+        public SitemapManager()
+        {
+            m_Sites = SitemapManagerConfiguration.GetSites();
+            if (m_Sites.Count > 0)
+            {
+                foreach (DictionaryEntry site in m_Sites)
+                {
+                    if (!string.IsNullOrEmpty(site.Key.ToString()))
+                    {
+                        BuildSiteMap(site.Key.ToString(), site.Value.ToString());
+                    }
+
+                }
+                BuildSiteMapIndex();
+            }
+        }
+
+        private void BuildSiteMap(string sitename, string sitemapUrlNew)
+        {
+            if (!string.IsNullOrEmpty(sitename))
+            {
+                Site site = Sitecore.Sites.SiteManager.GetSite(sitename);
+                if (site != null && !string.IsNullOrEmpty(sitemapUrlNew))
+                {
+                    SiteContext siteContext = Factory.GetSite(sitename);
+                    string rootPath = siteContext.StartPath;
+
+                    List<Item> items = GetSitemapItems(rootPath);
+
+                    if (items.Count > 0)
+                    {
+                        string fullPath = MainUtil.MapPath(string.Concat("/", sitemapUrlNew));
+                        string xmlContent = this.BuildSitemapXML(items, site, siteContext);
+                        StreamWriter strWriter = new StreamWriter(fullPath, false);
+                        strWriter.Write(xmlContent);
+                        strWriter.Close();
+                    }
+                }
+            }
+        }
+
+        private void BuildSiteMapIndex()
+        {
+            string fullPath = MainUtil.MapPath(string.Concat("/", SitemapManagerConfiguration.SitemapIndexFilename));
+            string xmlContent = this.BuildSitemapIndexXML();
+
+            StreamWriter strWriter = new StreamWriter(fullPath, false);
+            strWriter.Write(xmlContent);
+            strWriter.Close();
+        }
+
+        private string BuildSitemapIndexXML()
+        {
+            XmlDocument doc = new XmlDocument();
+
+            XmlNode declarationNode = doc.CreateXmlDeclaration("1.0", "UTF-8", null);
+            doc.AppendChild(declarationNode);
+            XmlNode urlsetNode = doc.CreateElement("sitemapindex");
+            XmlAttribute xmlnsAttr = doc.CreateAttribute("xmlns");
+            xmlnsAttr.Value = SitemapManagerConfiguration.XmlnsTpl;
+            urlsetNode.Attributes.Append(xmlnsAttr);
+
+            doc.AppendChild(urlsetNode);
+
+            foreach (DictionaryEntry siteEntry in m_Sites)
+            {
+                Site site = Sitecore.Sites.SiteManager.GetSite(siteEntry.Key.ToString());
+                if (site != null)
+                {
+                    string filename = siteEntry.Value.ToString();
+
+                    string serverUrl = SitemapManagerConfiguration.GetServerUrlBySite(site.Name);
+
+                    doc = this.BuildSitemapIndexItem(doc, string.Format("{0}/{1}", serverUrl, filename));
+                }
+            }
+
+            return doc.OuterXml;
+        }
+
+        private XmlDocument BuildSitemapIndexItem(XmlDocument doc, string filename)
+        {
+            string lastMod = HtmlEncode(System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:sszzz"));
+
+            XmlNode sitemapSetNode = doc.LastChild;
+
+            XmlNode sitemapNode = doc.CreateElement("sitemap");
+            sitemapSetNode.AppendChild(sitemapNode);
+
+            XmlNode locNode = doc.CreateElement("loc");
+            sitemapNode.AppendChild(locNode);
+            locNode.AppendChild(doc.CreateTextNode(filename));
+
+            XmlNode lastmodNode = doc.CreateElement("lastmod");
+            sitemapNode.AppendChild(lastmodNode);
+            lastmodNode.AppendChild(doc.CreateTextNode(lastMod));
+
+            return doc;
+        }
+
+        public bool SubmitSitemapToSearchenginesByHttp()
+        {
+            if (!SitemapManagerConfiguration.IsProductionEnvironment)
+                return false;
+
+            bool result = false;
+            Item sitemapConfig = Db.Items[SitemapManagerConfiguration.SitemapConfigurationItemPath];
+            if (sitemapConfig != null)
+            {
+                string engines = sitemapConfig[Templates.SitemapSelector.Fields.SearchEngine];
+                foreach (string id in engines.Split('|'))
+                {
+                    Item engine = Db.Items[id];
+                    if (engine != null)
+                    {
+                        string engineHttpRequestString = engine[Templates.SitemapSearchEngine.Fields.HttpRequestString];
+                        if (!string.IsNullOrEmpty(engineHttpRequestString))
+                        {
+                            foreach (string sitemapUrl in m_Sites.Values)
+                                this.SubmitEngine(engineHttpRequestString, sitemapUrl);
+                        }
+                    }
+                }
+                result = true;
+            }
+
+            return result;
+        }
+
+        private string BuildSitemapXML(List<Item> items, Site site, SiteContext siteContext)
+        {
+            if (items.Count > 1 && site != null && siteContext != null)
+            {
+                XmlDocument doc = new XmlDocument();
+                string url = "";
+
+                XmlNode declarationNode = doc.CreateXmlDeclaration("1.0", "UTF-8", null);
+                doc.AppendChild(declarationNode);
+                XmlNode urlsetNode = doc.CreateElement("urlset");
+                XmlAttribute xmlnsAttr = doc.CreateAttribute("xmlns");
+                xmlnsAttr.Value = SitemapManagerConfiguration.XmlnsTpl;
+                urlsetNode.Attributes.Append(xmlnsAttr);
+
+                doc.AppendChild(urlsetNode);
+                Sitecore.Globalization.Language language = Language.Parse(siteContext.Language);
+                Sitecore.Data.Database db = Sitecore.Configuration.Factory.GetDatabase("web");
+
+                foreach (Item itm in items)
+                {
+                    if (itm != null)
+                    {
+                        // If an item version exists in the site's default language
+                        if (Sitecore.Data.Managers.ItemManager.GetVersions(itm, language).Count == 0)
+                        {
+                            if (itm["__Enable item fallback"] == "1")
+                            {
+                                Language lang = fallback(itm, language, db);
+                                if (lang != null)
+                                {
+                                    if (Sitecore.Data.Managers.ItemManager.GetVersions(itm, lang).Count == 0)
+                                    {
+                                        Language chainlang = fallback(itm, lang, db);
+                                        if (chainlang != null)
+                                        {
+                                            language = lang;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        language = lang;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                language = Language.Parse(siteContext.Language);
+                            }
+                        }
+                        if (language != null && Sitecore.Data.Managers.ItemManager.GetVersions(itm, language).Count > 0 && site != null)
+                        {
+                            url = HtmlEncode(this.GetItemUrl(itm, site));
+                            if (!string.IsNullOrEmpty(url))
+                            {
+                                doc = this.BuildSitemapItem(doc, itm, site, url);
+                            }
+                        }
+                    }
+                }
+                return doc.OuterXml;
+            }
+            return string.Empty;
+
+        }
+        private Language fallback(Item itm, Language language, Database db)
+        {
+
+            ID contextLanguageId = LanguageManager.GetLanguageItemId(language, db);
+            Item contextLanguage = db.GetItem(contextLanguageId);
+            string fallback = contextLanguage["Fallback Language"];
+            if (!string.IsNullOrEmpty(fallback))
+            {
+                language = Language.Parse(fallback);
+                return language;
+            }
+            return null;
+        }
+        private XmlDocument BuildSitemapItem(XmlDocument doc, Item item, Site site, string url)
+        {
+            string lastMod = HtmlEncode(item.Statistics.Updated.ToString("yyyy-MM-ddTHH:mm:sszzz"));
+
+            XmlNode urlsetNode = doc.LastChild;
+
+            XmlNode urlNode = doc.CreateElement("url");
+            urlsetNode.AppendChild(urlNode);
+
+            XmlNode locNode = doc.CreateElement("loc");
+            urlNode.AppendChild(locNode);
+            locNode.AppendChild(doc.CreateTextNode(url));
+
+            XmlNode lastmodNode = doc.CreateElement("lastmod");
+            urlNode.AppendChild(lastmodNode);
+            lastmodNode.AppendChild(doc.CreateTextNode(lastMod));
+
+            return doc;
+        }
+
+        private string GetItemUrl(Item item, Site site)
+        {
+            try
+            {
+                if (item != null && site != null)
+                {
+                    Sitecore.Links.UrlOptions options = Sitecore.Links.UrlOptions.DefaultOptions;
+                    options.SiteResolving = Sitecore.Configuration.Settings.Rendering.SiteResolving;
+                    options.Site = SiteContext.GetSite(site.Name);
+                    options.AlwaysIncludeServerUrl = false;
+                    string hostName = options.Site.HostName;
+                    options.SiteResolving = true;
+                    string targetHostName = options.Site.TargetHostName;
+                    if (string.IsNullOrEmpty(targetHostName) && !string.IsNullOrEmpty(hostName))
+                    {
+                        targetHostName = options.Site.HostName;
+                    }
+                    else
+                    {
+
+                        hostName = targetHostName;
+                    }
+                    string serverUrl = SitemapManagerConfiguration.GetServerUrlBySite(site.Name);
+                    string itemUrl = string.Empty;
+                    try
+                    {
+                        itemUrl = Sitecore.Links.LinkManager.GetItemUrl(item, options);
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Error("GetItemUrl Sitemap is null" + item.ID + ex.InnerException.ToString());
+                    }
+                    if (itemUrl != null && !string.IsNullOrEmpty(itemUrl))
+                    {
+                        itemUrl = itemUrl.Replace("://" + hostName, "");
+                        if (itemUrl.StartsWith("http"))
+                        {
+                            return itemUrl;
+                        }
+                        else
+                        {
+                            return string.Format("{0}{1}", serverUrl, itemUrl);
+                        }
+                    }
+                }
+                return string.Empty;
+            }
+            catch (Exception ex)
+            {
+                log.Error("GetItemUrl Sitemap is null" + item.ID + ex.InnerException.ToString());
+                return string.Empty;
+            }
+
+
+        }
+
+        private static string HtmlEncode(string text)
+        {
+            string result = HttpUtility.HtmlEncode(text);
+
+            return result;
+        }
+
+        private void SubmitEngine(string engine, string sitemapUrl)
+        {
+            //Check if it is not localhost because search engines returns an error
+            if (!sitemapUrl.Contains("http://localhost"))
+            {
+                string request = string.Concat(engine, HtmlEncode(sitemapUrl));
+
+                System.Net.HttpWebRequest httpRequest = (System.Net.HttpWebRequest)System.Net.HttpWebRequest.Create(request);
+                try
+                {
+                    System.Net.WebResponse webResponse = httpRequest.GetResponse();
+
+                    System.Net.HttpWebResponse httpResponse = (System.Net.HttpWebResponse)webResponse;
+                    if (httpResponse.StatusCode != System.Net.HttpStatusCode.OK)
+                    {
+                        Log.Error(string.Format("Cannot submit sitemap to \"{0}\"", engine), this);
+                    }
+                }
+                catch
+                {
+                    Log.Warn(string.Format("The serachengine \"{0}\" returns an 404 error", request), this);
+                }
+            }
+        }
+
+
+        private List<Item> GetSitemapItems(string rootPath)
+        {
+            if (!string.IsNullOrEmpty(rootPath))
+            {
+                Item contentRoot = Db.Items[rootPath];
+                if (contentRoot == null)
+                {
+                    return new List<Item>();
+                }
+
+                List<Item> descendants;
+                using (var context = ContentSearchManager.GetIndex((SitecoreIndexableItem)contentRoot).CreateSearchContext())
+                {
+                    descendants = context.GetQueryable<SearchResultItem>().Where(i => i.Path.Contains(contentRoot.Paths.FullPath)).Select(i => (Item)i.GetItem()).ToList();
+                }
+                if (descendants.Count > 0)
+                {
+                    descendants = descendants.Where(i => i[Templates.Sitemap.Fields.IncludeInSitemap.ToString()] == "1").Where(item => HasLayout(item, DefaultDevice)).GroupBy(p => p.ID).Select(g => g.First()).ToList();
+                }
+
+                descendants.Insert(0, contentRoot);
+                return descendants;
+            }
+            return null;
+        }
+
+        private bool IncludeInSitemap(Item item)
+        {
+            return item.IsDerived(Templates.Sitemap.ID) && (MainUtil.GetBool(item[Templates.Sitemap.Fields.IncludeInSitemap], false));
+        }
+
+        private static bool HasLayout(Item item, DeviceItem device)
+        {
+            bool hasLayout = false;
+
+            if (item != null && item.Visualization != null)
+            {
+                ID layoutId = item.Visualization.GetLayoutID(device);
+                hasLayout = Guid.Empty != layoutId.Guid;
+            }
+
+            return hasLayout;
+        }
+
+        private List<string> BuildListFromString(string str, char separator)
+        {
+            string[] enabledTemplates = str.Split(separator);
+            var selected = from dtp in enabledTemplates
+                           where !string.IsNullOrEmpty(dtp)
+                           select dtp;
+
+            List<string> result = selected.ToList();
+
+            return result;
+        }
+        private IEnumerable<Language> GetLanguages()
+        {
+            Sitecore.Data.Database db = Sitecore.Data.Database.GetDatabase(SitemapManagerConfiguration.WorkingDatabase);
+            return LanguageManager.GetLanguages(db);
+        }
+
+    }
+}

--- a/src/Feature/Sitemap/code/Templates.cs
+++ b/src/Feature/Sitemap/code/Templates.cs
@@ -1,0 +1,72 @@
+﻿namespace Sitecore.Feature.Sitemap
+{
+    using Sitecore.Data;
+
+    public struct Templates
+    {
+        public struct SitemapXMLSettings
+        {
+            public static readonly ID ID = new ID("{152EC1AE-4486-4519-A227-0E59BC812810}");
+
+            public struct Fields
+            {
+                public static readonly ID GenerateSitempXML = new ID("{A816BDC8-D5AF-4845-911B-AE876BBDF10A}");
+                public static readonly ID GenerateSitempXMLOnPublishing = new ID("{4A26D031-8500-4DDB-B965-516FD394F959}");
+                public static readonly ID GenerateSitemapXMLByScheduler = new ID("{E260D3EA-5DD2-4D6E-AF48-D01A2091DCAC}");
+                public static readonly ID IsProduction = new ID("{DB120AB0-733C-4B13-8C3F-9DDEFCE1EFF2}");
+            }
+        }
+        public struct Sitemap
+        {
+            public static readonly ID ID = new ID("{8DCF7961-9470-4707-9FE0-3B1A372255D0}");
+
+            public struct Fields
+            {
+                public static readonly ID IncludeInSitemap = new ID("{B8EFA7EA-7744-46B1-9C25-FF92FA83128B}");
+            }
+        }
+
+        public struct SitemapSelector
+        {
+            public static readonly ID ID = new ID("{7381526C-FA87-4292-B617-1C8E42527364}");
+
+            public struct Fields
+            {
+                public static readonly ID SearchEngine = new ID("{FC42E276-D0BC-4888-B645-CA141949759D}");
+                public static readonly ID Sites = new ID("{3634EAD8-A127-4535-A196-DB1440E9E213}");
+            }
+        }
+
+        public struct SitemapSearchEngine
+        {
+            public static readonly ID ID = new ID("{7034C3F4-C66E-4C71-B9CB-A33D7FF5BFDD}");
+
+            public struct Fields
+            {
+                public static readonly ID HttpRequestString = new ID("{D6EDC5AA-5615-4A99-B90A-6AAADBC83CA1}");
+            }
+        }
+
+        public struct Sites
+        {
+            public static readonly ID ID = new ID("{EB76FCDA-DE99-44AF-90F7-8207D6786611}");
+
+            public struct Fields
+            {
+                public static readonly ID SiteName = new ID("{54A8E7A2-BBB9-4D99-A665-FF075447249E}");
+                public static readonly ID ServerURL = new ID("{5F7F5D28-9183-4AC6-8FB6-31242D94D67B}");
+                public static readonly ID FileName = new ID("{13CDD377-9B9E-4BC6-88FE-4C37AF98B9C0}");
+            }
+        }
+
+        public struct Navigable
+        {
+            public static readonly ID ID = new ID("{A1CBA309-D22B-46D5-80F8-2972C185363F}");
+
+            public struct Fields
+            {
+                public static readonly ID NavigationTitle = new ID("{1B483E91-D8C4-4D19-BA03-462074B55936}");
+            }
+        }
+    }
+}

--- a/src/Feature/Sitemap/code/Views/Sitemap/Sitemap.cshtml
+++ b/src/Feature/Sitemap/code/Views/Sitemap/Sitemap.cshtml
@@ -1,0 +1,75 @@
+﻿@using Sitecore.Mvc
+@using Sitecore.Feature.Sitemap
+@using Sitecore.Mvc.Presentation
+@using Sitecore.Feature.Sitemap.Models.Sitemap
+@using Sitecore.Foundation.SitecoreExtensions.Extensions
+@model Sitecore.Feature.Sitemap.Models.Sitemap.SitemapItems
+
+@{
+    int NoOfColumns = 1;
+    int TotalNoOfColumns = 12;
+    if (RenderingContext.Current.Rendering.Parameters["Columns"] != null)
+    {
+        NoOfColumns = Int32.Parse(RenderingContext.Current.Rendering.Parameters["Columns"]);
+    }
+
+    if (RenderingContext.Current.Rendering.Parameters["TotalNoOfColumns"] != null)
+    {
+        TotalNoOfColumns = Int32.Parse(RenderingContext.Current.Rendering.Parameters["TotalNoOfColumns"]);
+    }
+
+
+
+    var perColumnSize = TotalNoOfColumns / NoOfColumns;
+}
+<section class="layer layer-grid sitemap-page">
+    <div class="container-fluid">
+        <div class="row">
+
+            <div class="col-sm-@TotalNoOfColumns">
+                @foreach (var item in Model.Items)
+                {
+                    <div class="col-sm-@perColumnSize">
+                        @if(@item.Item.FieldHasValue(Templates.Navigable.Fields.NavigationTitle)) {
+                        <a href="@item.Url" target="_self">@Html.Sitecore().Field(Templates.Navigable.Fields.NavigationTitle.ToString(), item.Item)</a>
+                        }
+                        else {
+                        <a href="@item.Url" target="_self">@item.Item.Name</a>
+                        }
+                        @if (item.ChildItems != null && item.ChildItems.Items.Count > 0)
+                {
+                            @ShowTree(item)
+                        }
+                    </div>
+                }
+            </div>
+
+            @helper ShowTree(SitemapItem item)
+            {
+            <ul>
+                @{
+                    if (item.ChildItems != null && item.ChildItems.Items.Count > 0)
+                    {
+                        foreach (var sItem in item.ChildItems.Items)
+                        {
+                            <li>
+                                @if(@item.Item.FieldHasValue(Templates.Navigable.Fields.NavigationTitle)) {
+                                <a href="@sItem.Url" target="_self">@Html.Sitecore().Field(Templates.Navigable.Fields.NavigationTitle.ToString(), sItem.Item)</a>
+                                }
+                                else {
+                                <a href="@sItem.Url" target="_self">@sItem.Item.Name</a>
+                                }
+                                @if (item.ChildItems != null && item.ChildItems.Items.Count > 0)
+                                {
+                                @ShowTree(sItem)
+                                }
+                            </li>
+                           
+                        }
+                    }
+                }
+            </ul>
+}
+        </div>
+    </div>
+</section>

--- a/src/Feature/Sitemap/code/Views/Sitemap/SitemapWithExpend.cshtml
+++ b/src/Feature/Sitemap/code/Views/Sitemap/SitemapWithExpend.cshtml
@@ -1,0 +1,60 @@
+﻿@using Sitecore.Mvc
+@using Sitecore.Feature.Sitemap
+@using Sitecore.Feature.Sitemap.Models.Sitemap
+@using Sitecore.Foundation.SitecoreExtensions.Extensions
+@model Sitecore.Feature.Sitemap.Models.Sitemap.SitemapItems
+<section class="layer layer-grid sitemap-page">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-sm-12">
+                @foreach (var item in Model.Items)
+                {
+                    <div class="col-sm" style="padding:5px 0;">
+
+                        @if (item.ChildItems != null && item.ChildItems.Items.Count > 0)
+                        {
+                            <a href="#" class="expand-btn" data-id="@item.Item.ID.ToString()"><i class="fa fa-plus-square" aria-hidden="true"></i></a> <a href="@item.Url" target="_self">@Html.Sitecore().Field(Templates.Navigable.Fields.NavigationTitle.ToString(), item.Item)</a>
+                        }
+                        else
+                        {
+                            <a href="@item.Url" target="_self">@Html.Sitecore().Field(Templates.Navigable.Fields.NavigationTitle.ToString(), item.Item)</a>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</section>
+<script type="text/javascript">
+    $("div, ul").on("click", ".expand-btn", function () {
+        var itemID = $(this).attr('data-id');
+        $.ajax({
+            url: window.location.href + "?DS=" + itemID,
+            type: "POST",
+            context: this,
+            data: { scController: "Sitemap", scAction: "SitemapWithExpend", itemID: itemID },
+            success: function (data) {
+                $(this).parent().append(data);
+                $(this).removeClass('expand-btn');
+                $(this).addClass("collapse-btn");
+                $(this).find('i').removeClass('fa-plus-square');
+                $(this).find('i').addClass('fa-minus-square');
+            },
+            error: function (data) {
+                console.log("error", data);
+            }
+        });
+        return false;
+    });
+    $("div, ul, li").on("click", ".collapse-btn", function () {
+        $(this).parent().find('>ul').remove();
+        $(this).addClass('expand-btn');
+        $(this).removeClass("collapse-btn");
+        $(this).find('i').addClass('fa-plus-square');
+        $(this).find('i').removeClass('fa-minus-square');
+        return false;
+    });
+
+</script>
+
+

--- a/src/Feature/Sitemap/code/Views/Sitemap/_SitemapWithExpend.cshtml
+++ b/src/Feature/Sitemap/code/Views/Sitemap/_SitemapWithExpend.cshtml
@@ -1,0 +1,26 @@
+﻿@using Sitecore.Mvc
+@using Sitecore.Feature.Sitemap
+@using Sitecore.Mvc.Presentation
+@using Sitecore.Feature.Sitemap.Models.Sitemap
+@using Sitecore.Foundation.SitecoreExtensions.Extensions
+@model Sitecore.Feature.Sitemap.Models.Sitemap.SitemapItems
+<ul>
+    @foreach (var sItem in Model.Items)
+    {
+        <li>
+            @if (sItem.ChildItems != null && sItem.ChildItems.Items.Count > 0)
+            {
+                <a href="#" class="expand-btn" data-id="@sItem.Item.ID.ToString()"><i class="fa fa-plus-square" aria-hidden="true"></i></a> <a href="@sItem.Url" target="_self">@Html.Sitecore().Field(Templates.Navigable.Fields.NavigationTitle.ToString(), sItem.Item)</a>
+
+            }
+
+            else
+            {
+
+                <a href="@sItem.Url" target="_self">@Html.Sitecore().Field(Templates.Navigable.Fields.NavigationTitle.ToString(), sItem.Item)</a>
+            }
+        </li>
+    }
+</ul>
+
+

--- a/src/Feature/Sitemap/code/Views/Web.config
+++ b/src/Feature/Sitemap/code/Views/Web.config
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0"?>
+
+<configuration>
+  <configSections>
+    <sectionGroup name="system.web.webPages.razor"
+                  type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host"
+               type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+               requirePermission="false" />
+      <section name="pages"
+               type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+               requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+
+  <system.web.webPages.razor>
+    <host
+      factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <pages pageBaseType="System.Web.Mvc.WebViewPage">
+      <namespaces>
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Optimization" />
+        <add namespace="System.Web.Routing" />
+        <add namespace="Sitecore.Mvc" />
+      </namespaces>
+    </pages>
+  </system.web.webPages.razor>
+
+  <appSettings>
+    <add key="webpages:Enabled" value="false" />
+  </appSettings>
+
+  <system.webServer>
+    <handlers>
+      <remove name="BlockViewHandler" />
+      <add name="BlockViewHandler" path="*.cshtml" verb="*" preCondition="integratedMode"
+           type="System.Web.HttpNotFoundHandler" />
+    </handlers>
+  </system.webServer>
+</configuration>

--- a/src/Feature/Sitemap/code/Web.Debug.config
+++ b/src/Feature/Sitemap/code/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/Feature/Sitemap/code/Web.Release.config
+++ b/src/Feature/Sitemap/code/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/Feature/Sitemap/code/Web.config
+++ b/src/Feature/Sitemap/code/Web.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.6" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation debug="true" targetFramework="4.6" />
+    <httpRuntime targetFramework="4.5" />
+  </system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Sitecore.Kernel" />
+        <bindingRedirect oldVersion="1.0.0.0-8.1.0.0" newVersion="8.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/Feature/Sitemap/code/packages.config
+++ b/src/Feature/Sitemap/code/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net46" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net46" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
+  <package id="Sitecore.ContentSearch.NoReferences" version="8.2.161115" targetFramework="net46" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.161115" targetFramework="net46" developmentDependency="true" />
+  <package id="Sitecore.Mvc.NoReferences" version="8.2.161115" targetFramework="net46" developmentDependency="true" />
+</packages>

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap.yml
@@ -1,0 +1,14 @@
+﻿---
+ID: "dd3d8f45-4579-46d6-a599-4dbc7eff539e"
+Parent: "08477468-d438-43d4-9d6a-6d84a611971c"
+Template: "1fcccb76-bd22-4d1c-ac66-6cd3d02df281"
+Path: /sitecore/system/Modules/Sitemap
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123502Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration.yml
@@ -1,0 +1,26 @@
+﻿---
+ID: "076374b1-550c-4872-a1db-d41161105019"
+Parent: "dd3d8f45-4579-46d6-a599-4dbc7eff539e"
+Template: "edbc9b84-815d-423b-a79f-6c5105f9edc2"
+Path: /sitecore/system/Modules/Sitemap/Sitemap Configuration
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123506Z
+    - ID: "3634ead8-a127-4535-a196-db1440e9e213"
+      Hint: Sites
+      Type: Multilist
+      Value: "{DC9F6734-5D41-448F-961F-937378D6BF6C}"
+    - ID: "a816bdc8-d5af-4845-911b-ae876bbdf10a"
+      Hint: GenerateSitemapXML
+      Type: Checkbox
+      Value: 1
+    - ID: "e260d3ea-5dd2-4d6e-af48-d01a2091dcac"
+      Hint: GenerateSitemapXMLByScheduler
+      Type: Checkbox
+      Value: 1

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Search Engines.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Search Engines.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "b2fd704e-23bc-46ce-a2f9-c48f8c351a35"
+Parent: "076374b1-550c-4872-a1db-d41161105019"
+Template: "6dd5b041-59d3-4431-a906-24b7149b0ba3"
+Path: /sitecore/system/Modules/Sitemap/Sitemap Configuration/Search Engines
+DB: master
+SharedFields:
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 0
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160321T072339Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Search Engines/Google.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Search Engines/Google.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "fb084345-f377-41cb-8671-46f2410884a4"
+Parent: "b2fd704e-23bc-46ce-a2f9-c48f8c351a35"
+Template: "3c99a5f7-4e7c-40e7-932c-611627d981e1"
+Path: /sitecore/system/Modules/Sitemap/Sitemap Configuration/Search Engines/Google
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123511Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+    - ID: "d6edc5aa-5615-4a99-b90a-6aaadbc83ca1"
+      Hint: HttpRequestString
+      Value: "Http://google.com/webmasters/sitemaps/ping?sitemap="

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Search Engines/Yahoo.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Search Engines/Yahoo.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "878c7478-0606-4081-abde-4d65976ccf82"
+Parent: "b2fd704e-23bc-46ce-a2f9-c48f8c351a35"
+Template: "3c99a5f7-4e7c-40e7-932c-611627d981e1"
+Path: /sitecore/system/Modules/Sitemap/Sitemap Configuration/Search Engines/Yahoo
+DB: master
+SharedFields:
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 50
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123516Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+    - ID: "d6edc5aa-5615-4a99-b90a-6aaadbc83ca1"
+      Hint: HttpRequestString
+      Value: "http://search.yahooapis.com/SiteExplorerService/V1/ping?sitemap="

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Sites.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Sites.yml
@@ -1,0 +1,14 @@
+﻿---
+ID: "7876fbee-0692-4020-9aee-73a279bdd12e"
+Parent: "076374b1-550c-4872-a1db-d41161105019"
+Template: "dc552d98-54ca-4e1d-9843-a4e1c7a9b9bb"
+Path: /sitecore/system/Modules/Sitemap/Sitemap Configuration/Sites
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160321T072358Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Sites/Site1.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.System/Sitemap/Sitemap Configuration/Sites/Site1.yml
@@ -1,0 +1,27 @@
+﻿---
+ID: "dc9f6734-5d41-448f-961f-937378d6bf6c"
+Parent: "7876fbee-0692-4020-9aee-73a279bdd12e"
+Template: "66aace6f-59c6-471a-87aa-9c21b5df5d66"
+Path: /sitecore/system/Modules/Sitemap/Sitemap Configuration/Sites/Site1
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "13cdd377-9b9e-4bc6-88fe-4c37af98b9c0"
+      Hint: FileName
+      Value: sitemap1.xml
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160321T072404Z
+    - ID: "54a8e7a2-bbb9-4d99-a665-ff075447249e"
+      Hint: SiteName
+      Value: habitat
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+    - ID: "5f7f5d28-9183-4ac6-8fb6-31242d94d67b"
+      Hint: ServerURL
+      Value: "http://sitecoredemo.local"

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Parent: "8f343079-3cc5-4ef7-bc27-32addb46f45e"
+Template: "0437fee2-44c9-46a6-abe9-28858d9fee8c"
+Path: /sitecore/templates/Feature/Sitemap
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T122157Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "0437fee2-44c9-46a6-abe9-28858d9fee8c"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123130Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Search Engine Folder.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Search Engine Folder.yml
@@ -1,0 +1,29 @@
+﻿---
+ID: "6dd5b041-59d3-4431-a906-24b7149b0ba3"
+Parent: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Search Engine Folder
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Applications/32x32/folder_network.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{32EC0852-1715-4C62-B638-6816F3439F0D}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142528Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Search Engine Folder/__Standard Values.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Search Engine Folder/__Standard Values.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "32ec0852-1715-4c62-b638-6816f3439f0d"
+Parent: "6dd5b041-59d3-4431-a906-24b7149b0ba3"
+Template: "6dd5b041-59d3-4431-a906-24b7149b0ba3"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Search Engine Folder/__Standard Values
+DB: master
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Type: TreelistEx
+  Value: "{3C99A5F7-4E7C-40E7-932C-611627D981E1}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142600Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Site.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Site.yml
@@ -1,0 +1,26 @@
+﻿---
+ID: "66aace6f-59c6-471a-87aa-9c21b5df5d66"
+Parent: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Site
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Network/32x32/earth.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{EB76FCDA-DE99-44AF-90F7-8207D6786611}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142820Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sitemap Configuration.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sitemap Configuration.yml
@@ -1,0 +1,31 @@
+﻿---
+ID: "edbc9b84-815d-423b-a79f-6c5105f9edc2"
+Parent: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Sitemap Configuration
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: network/32x32/node.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: |
+    {152EC1AE-4486-4519-A227-0E59BC812810}
+    {7381526C-FA87-4292-B617-1C8E42527364}
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{068A2CAA-6B59-405F-9EAF-BEDB00D50F16}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123219Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sitemap Configuration/__Standard Values.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sitemap Configuration/__Standard Values.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "068a2caa-6b59-405f-9eaf-bedb00d50f16"
+Parent: "edbc9b84-815d-423b-a79f-6c5105f9edc2"
+Template: "edbc9b84-815d-423b-a79f-6c5105f9edc2"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Sitemap Configuration/__Standard Values
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160518T142758Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sitemap Search Engine.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sitemap Search Engine.yml
@@ -1,0 +1,26 @@
+﻿---
+ID: "3c99a5f7-4e7c-40e7-932c-611627d981e1"
+Parent: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Sitemap Search Engine
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: network/32x32/download.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{7034C3F4-C66E-4C71-B9CB-A33D7FF5BFDD}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123313Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/SitemapXML Folder.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/SitemapXML Folder.yml
@@ -1,0 +1,29 @@
+﻿---
+ID: "1fcccb76-bd22-4d1c-ac66-6cd3d02df281"
+Parent: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/SitemapXML Folder
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Applications/32x32/folder_cubes.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{979C2767-DCA0-49E5-B5A7-FE6ADBE1BD41}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123143Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/SitemapXML Folder/__Standard Values.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/SitemapXML Folder/__Standard Values.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "979c2767-dca0-49e5-b5a7-fe6adbe1bd41"
+Parent: "1fcccb76-bd22-4d1c-ac66-6cd3d02df281"
+Template: "1fcccb76-bd22-4d1c-ac66-6cd3d02df281"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/SitemapXML Folder/__Standard Values
+DB: master
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Type: TreelistEx
+  Value: "{EDBC9B84-815D-423B-A79F-6C5105F9EDC2}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123202Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sites Folder.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sites Folder.yml
@@ -1,0 +1,29 @@
+﻿---
+ID: "dc552d98-54ca-4e1d-9843-a4e1c7a9b9bb"
+Parent: "181ed12e-2949-4d52-9c8d-a43f6327d8be"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Sites Folder
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Applications/32x32/folder_out.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{52F93784-5B76-4255-B0C3-87FB7E12B579}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142613Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sites Folder/__Standard Values.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/Pre Built Examples/Sites Folder/__Standard Values.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "52f93784-5b76-4255-b0c3-87fb7e12b579"
+Parent: "dc552d98-54ca-4e1d-9843-a4e1c7a9b9bb"
+Template: "dc552d98-54ca-4e1d-9843-a4e1c7a9b9bb"
+Path: /sitecore/templates/Feature/Sitemap/Pre Built Examples/Sites Folder/__Standard Values
+DB: master
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Type: TreelistEx
+  Value: "{66AACE6F-59C6-471A-87AA-9C21B5DF5D66}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142632Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "eb76fcda-de99-44af-90f7-8207d6786611"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/_Site
+DB: master
+SharedFields:
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142707Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "1e58fbaa-9672-442d-9abd-90514e6a1016"
+Parent: "eb76fcda-de99-44af-90f7-8207d6786611"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Feature/Sitemap/_Site/Content
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142803Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content/FileName.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content/FileName.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "13cdd377-9b9e-4bc6-88fe-4c37af98b9c0"
+Parent: "1e58fbaa-9672-442d-9abd-90514e6a1016"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_Site/Content/FileName
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 300
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142805Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content/ServerURL.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content/ServerURL.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "5f7f5d28-9183-4ac6-8fb6-31242d94d67b"
+Parent: "1e58fbaa-9672-442d-9abd-90514e6a1016"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_Site/Content/ServerURL
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 200
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142804Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content/SiteName.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Site/Content/SiteName.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "54a8e7a2-bbb9-4d99-a665-ff075447249e"
+Parent: "1e58fbaa-9672-442d-9abd-90514e6a1016"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_Site/Content/SiteName
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T142804Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Sitemap.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Sitemap.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "8dcf7961-9470-4707-9fe0-3b1a372255d0"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/_Sitemap
+DB: master
+SharedFields:
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170712T155708Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Sitemap/Include In Sitemap.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Sitemap/Include In Sitemap.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "c9a8e131-aa67-4b5b-8454-b37dd2bed4ce"
+Parent: "8dcf7961-9470-4707-9fe0-3b1a372255d0"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Feature/Sitemap/_Sitemap/Include In Sitemap
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170712T160152Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Sitemap/Include In Sitemap/Include in Sitemap.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_Sitemap/Include In Sitemap/Include in Sitemap.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "b8efa7ea-7744-46b1-9c25-ff92fa83128b"
+Parent: "c9a8e131-aa67-4b5b-8454-b37dd2bed4ce"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_Sitemap/Include In Sitemap/Include in Sitemap
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Checkbox
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170712T160212Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters.yml
@@ -1,0 +1,26 @@
+﻿---
+ID: "eca3fe81-e2f4-4c8b-9c02-8c512125a620"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapParameters
+DB: master
+SharedFields:
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{8CA06D6A-B353-44E8-BC31-B528C7306971}"
+- ID: "f7d48a55-2158-4f02-9356-756654404f73"
+  Hint: __Standard values
+  Value: "{541231D1-9115-439C-AACA-AC32D9F9CFD5}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170713T161052Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/Sitemap Settings.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/Sitemap Settings.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "b8296f64-ffc3-4fae-8c9d-75205dc238a2"
+Parent: "eca3fe81-e2f4-4c8b-9c02-8c512125a620"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapParameters/Sitemap Settings
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170713T161136Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/Sitemap Settings/Columns.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/Sitemap Settings/Columns.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "a7078b68-6b2a-443f-9c14-1d9672caa602"
+Parent: "b8296f64-ffc3-4fae-8c9d-75205dc238a2"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapParameters/Sitemap Settings/Columns
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Number
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: Number of Columns
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170713T161136Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/Sitemap Settings/TotalNoOfColumns.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/Sitemap Settings/TotalNoOfColumns.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "556b3e18-30a7-4422-8c1c-94a1d50819e4"
+Parent: "b8296f64-ffc3-4fae-8c9d-75205dc238a2"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapParameters/Sitemap Settings/TotalNoOfColumns
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Number
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 50
+Languages:
+- Language: en
+  Fields:
+  - ID: "19a69332-a23e-4e70-8d16-b2640cb24cc8"
+    Hint: Title
+    Value: Total No Of Columns
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170714T064150Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/__Standard Values.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapParameters/__Standard Values.yml
@@ -1,0 +1,14 @@
+﻿---
+ID: "541231d1-9115-439c-aaca-ac32d9f9cfd5"
+Parent: "eca3fe81-e2f4-4c8b-9c02-8c512125a620"
+Template: "eca3fe81-e2f4-4c8b-9c02-8c512125a620"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapParameters/__Standard Values
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170713T162237Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSearchEngine.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSearchEngine.yml
@@ -1,0 +1,26 @@
+﻿---
+ID: "7034c3f4-c66e-4c71-b9cb-a33d7ff5bfdd"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSearchEngine
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: Applications/16x16/form_blue.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T122435Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSearchEngine/Content.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSearchEngine/Content.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "2f625a4d-1fac-4891-981c-fcb09d924093"
+Parent: "7034c3f4-c66e-4c71-b9cb-a33d7ff5bfdd"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSearchEngine/Content
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T122500Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSearchEngine/Content/HttpRequestString.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSearchEngine/Content/HttpRequestString.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "d6edc5aa-5615-4a99-b90a-6aaadbc83ca1"
+Parent: "2f625a4d-1fac-4891-981c-fcb09d924093"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSearchEngine/Content/HttpRequestString
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T122500Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "7381526c-fa87-4292-b617-1c8e42527364"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSelectors
+DB: master
+SharedFields:
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T122940Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors/Content.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors/Content.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "3b1beb56-704b-40f2-b615-e156bf41cb14"
+Parent: "7381526c-fa87-4292-b617-1c8e42527364"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSelectors/Content
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T122953Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors/Content/SearchEngines.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors/Content/SearchEngines.yml
@@ -1,0 +1,24 @@
+﻿---
+ID: "fc42e276-d0bc-4888-b645-ca141949759d"
+Parent: "3b1beb56-704b-40f2-b615-e156bf41cb14"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSelectors/Content/SearchEngines
+DB: master
+SharedFields:
+- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
+  Hint: Source
+  Value: "query:/sitecore/system/Modules//*[@@templateid='{3C99A5F7-4E7C-40E7-932C-611627D981E1}']"
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Multilist
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T123008Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors/Content/Sites.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapSelectors/Content/Sites.yml
@@ -1,0 +1,24 @@
+﻿---
+ID: "3634ead8-a127-4535-a196-db1440e9e213"
+Parent: "3b1beb56-704b-40f2-b615-e156bf41cb14"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapSelectors/Content/Sites
+DB: master
+SharedFields:
+- ID: "1eb8ae32-e190-44a6-968d-ed904c794ebf"
+  Hint: Source
+  Value: "query:/sitecore/system/Modules//*[@@templateid='{66AACE6F-59C6-471A-87AA-9C21B5DF5D66}']"
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Multilist
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 200
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160321T072606Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings.yml
@@ -1,0 +1,23 @@
+﻿---
+ID: "152ec1ae-4486-4519-a227-0e59bc812810"
+Parent: "5d2e2b91-00e7-4a36-9e46-01ef8cf64141"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapXMLSettings
+DB: master
+SharedFields:
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T142301Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "bb5bb787-cb2a-44ee-b2ab-b2c98c7bb526"
+Parent: "152ec1ae-4486-4519-a227-0e59bc812810"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapXMLSettings/Content
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T142316Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXML.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXML.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "a816bdc8-d5af-4845-911b-ae876bbdf10a"
+Parent: "bb5bb787-cb2a-44ee-b2ab-b2c98c7bb526"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXML
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Checkbox
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160223T142329Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXMLByScheduler.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXMLByScheduler.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "e260d3ea-5dd2-4d6e-af48-d01a2091dcac"
+Parent: "bb5bb787-cb2a-44ee-b2ab-b2c98c7bb526"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXMLByScheduler
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Checkbox
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 175
+Languages:
+- Language: en
+  Fields:
+  - ID: "19a69332-a23e-4e70-8d16-b2640cb24cc8"
+    Hint: Title
+    Value: Generate Sitemap XML by Sitecore Scheduler
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170714T081637Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXMLPublishingEvent.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXMLPublishingEvent.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "4a26d031-8500-4ddb-b965-516fd394f959"
+Parent: "bb5bb787-cb2a-44ee-b2ab-b2c98c7bb526"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapXMLSettings/Content/GenerateSitemapXMLPublishingEvent
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Checkbox
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 150
+Languages:
+- Language: en
+  Fields:
+  - ID: "19a69332-a23e-4e70-8d16-b2640cb24cc8"
+    Hint: Title
+    Value: Generate Sitemap XML on Publishing End Event
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170714T081636Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/IsProduction.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.Templates/Sitemap/_SitemapXMLSettings/Content/IsProduction.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "db120ab0-733c-4b13-8c3f-9ddefce1eff2"
+Parent: "bb5bb787-cb2a-44ee-b2ab-b2c98c7bb526"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Feature/Sitemap/_SitemapXMLSettings/Content/IsProduction
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: Checkbox
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 200
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160318T143119Z

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Commands/Sitemap XML.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Commands/Sitemap XML.yml
@@ -1,0 +1,17 @@
+﻿---
+ID: "3a3a2461-af55-470b-b650-6115adc68e28"
+Parent: "3ebec263-b57e-4a3c-a232-7c70519f9908"
+Template: "a87a00b1-e6db-45ab-8b54-636fec3b5523"
+Path: /sitecore/system/Tasks/Commands/Sitemap XML
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160919T154404Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Commands/Sitemap XML/Sitemapxml Rebuild.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Commands/Sitemap XML/Sitemapxml Rebuild.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "38527d76-a3c9-415a-9635-bf5302668aca"
+Parent: "3a3a2461-af55-470b-b650-6115adc68e28"
+Template: "58119a3e-560e-4da6-97c6-1ace8a5b1219"
+Path: /sitecore/system/Tasks/Commands/Sitemap XML/Sitemapxml Rebuild
+DB: master
+SharedFields:
+- ID: "4bc75539-d5c4-487b-af35-ff13d62bd286"
+  Hint: Method
+  Value: Execute
+- ID: "752579a7-ef2f-45b7-b9d1-9b682308b7a5"
+  Hint: Type
+  Value: Sitecore.Feature.Sitemap.SitemapManager.SitemapHandler, Sitecore.Feature.Sitemap
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160919T154502Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Schedules/Sitemap XML.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Schedules/Sitemap XML.yml
@@ -1,0 +1,17 @@
+﻿---
+ID: "6c3ee76c-4bc1-469c-8b24-751c0d56fab4"
+Parent: "a705d262-5714-4880-9962-051e25f1416d"
+Template: "a87a00b1-e6db-45ab-8b54-636fec3b5523"
+Path: /sitecore/system/Tasks/Schedules/Sitemap XML
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160919T154547Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: sitecore\admin

--- a/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Schedules/Sitemap XML/Sitemapxml Rebuild.yml
+++ b/src/Feature/Sitemap/serialization/Feature.Sitemap.system.Tasks.Schedules/Sitemap XML/Sitemapxml Rebuild.yml
@@ -1,0 +1,39 @@
+﻿---
+ID: "788bff3c-54c6-4cea-abb9-13dc19e3dcc1"
+Parent: "6c3ee76c-4bc1-469c-8b24-751c0d56fab4"
+Template: "70244923-fa84-477c-8cbd-62f39642c42b"
+Path: /sitecore/system/Tasks/Schedules/Sitemap XML/Sitemapxml Rebuild
+DB: master
+SharedFields:
+- ID: "50be51f8-746d-4dc2-9c3b-b14abc5ce9b7"
+  Hint: Schedule
+  Value: "20140101|99990101|127|00:10:00"
+- ID: "62e64dbb-0a39-4dd7-ba05-7bd08c5404e0"
+  Hint: Command
+  Value: "{38527D76-A3C9-415A-9635-BF5302668ACA}"
+- ID: "a2c0c7a2-697d-40e2-9516-54e0c2d6028e"
+  Hint: Async
+  Value: 1
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160919T154617Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: "en-US"
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170120T172553Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\Anonymous

--- a/src/Project/Habitat/serialization/Habitat.Website.Content/Habitat/Home/Modules/Feature/Sitemap With Expand.yml
+++ b/src/Project/Habitat/serialization/Habitat.Website.Content/Habitat/Home/Modules/Feature/Sitemap With Expand.yml
@@ -1,0 +1,64 @@
+﻿---
+ID: "7dddb99f-9873-4547-a507-b636772ce7ae"
+Parent: "f7434df7-e32e-4f8c-a50e-27c476f4dc32"
+Template: "94a8c8e9-690b-4e65-98e7-f95800222767"
+Path: /sitecore/content/Habitat/Home/Modules/Feature/Sitemap With Expand
+DB: master
+SharedFields:
+- ID: "f1a1fe9e-a60c-4ddb-a3a0-bb5b29fe732e"
+  Hint: __Renderings
+  Type: layout
+  Value: |
+    <r xmlns:p="p" xmlns:s="s"
+      p:p="1">
+      <d
+        id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+        <r
+          uid="{B590073C-C71E-46F3-8237-C5CD3DEA6A3E}"
+          p:after="r[@uid='{20E3883C-C16D-41D7-B5D3-C4AC60D8386D}']"
+          s:ds=""
+          s:id="{D201A487-5099-48A1-8189-55944F70C6CB}"
+          s:par="Background&amp;ContainerIsFluid=1&amp;UseStaticPlaceholderNames=1"
+          s:ph="/page-layout" />
+        <r
+          uid="{66422117-69C1-4B62-9323-482F16C4F244}"
+          s:ds=""
+          s:id="{0AD8EC59-33EC-4103-AAD4-F3A49BFDB92C}"
+          s:par="Background&amp;ContainerIsFluid&amp;UseStaticPlaceholderNames=1"
+          s:ph="/page-layout/section" />
+        <r
+          uid="{3CDF4DD8-28A4-4185-8C09-A73CAA4633F7}"
+          s:ds=""
+          s:par=""
+          s:ph="/page-layout/section/col-huge" />
+        <r
+          uid="{565F9960-4E47-4DA4-9406-0A29DD09911F}"
+          s:ds=""
+          s:par=""
+          s:ph="/page-layout/section/col-huge" />
+        <r
+          uid="{A85893F9-5DF5-4C28-AC0F-67AD85D29661}"
+          p:after="r[@uid='{565F9960-4E47-4DA4-9406-0A29DD09911F}']"
+          s:ds=""
+          s:id="{198C413F-87DD-4DCA-8642-5459B22C8B7F}"
+          s:par="TotalNoOfColumns=12&amp;Columns=4"
+          s:ph="/page-layout/section/col-huge" />
+      </d>
+    </r>
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "1b483e91-d8c4-4d19-ba03-462074b55936"
+      Hint: NavigationTitle
+      Value: Sitemap
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170717T071857Z
+    - ID: "c30a013f-3cc8-4961-9837-1c483277084a"
+      Hint: Title
+      Value: Sitemap With Expand
+    - ID: "ca0479ce-0bfe-4522-83de-ba688b380a78"
+      Hint: BrowserTitle
+      Value: Sitemap

--- a/src/Project/Habitat/serialization/Habitat.Website.Content/Habitat/Home/Modules/Feature/Sitemap.yml
+++ b/src/Project/Habitat/serialization/Habitat.Website.Content/Habitat/Home/Modules/Feature/Sitemap.yml
@@ -1,0 +1,64 @@
+﻿---
+ID: "2ca4aa53-5b14-4f4a-969e-5653ad3a4726"
+Parent: "f7434df7-e32e-4f8c-a50e-27c476f4dc32"
+Template: "94a8c8e9-690b-4e65-98e7-f95800222767"
+Path: /sitecore/content/Habitat/Home/Modules/Feature/Sitemap
+DB: master
+SharedFields:
+- ID: "f1a1fe9e-a60c-4ddb-a3a0-bb5b29fe732e"
+  Hint: __Renderings
+  Type: layout
+  Value: |
+    <r xmlns:p="p" xmlns:s="s"
+      p:p="1">
+      <d
+        id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
+        <r
+          uid="{B590073C-C71E-46F3-8237-C5CD3DEA6A3E}"
+          p:after="r[@uid='{20E3883C-C16D-41D7-B5D3-C4AC60D8386D}']"
+          s:ds=""
+          s:id="{D201A487-5099-48A1-8189-55944F70C6CB}"
+          s:par="Background&amp;ContainerIsFluid=1&amp;UseStaticPlaceholderNames=1"
+          s:ph="/page-layout" />
+        <r
+          uid="{66422117-69C1-4B62-9323-482F16C4F244}"
+          s:ds=""
+          s:id="{0AD8EC59-33EC-4103-AAD4-F3A49BFDB92C}"
+          s:par="Background&amp;ContainerIsFluid&amp;UseStaticPlaceholderNames=1"
+          s:ph="/page-layout/section" />
+        <r
+          uid="{3CDF4DD8-28A4-4185-8C09-A73CAA4633F7}"
+          s:ds=""
+          s:par=""
+          s:ph="/page-layout/section/col-huge" />
+        <r
+          uid="{565F9960-4E47-4DA4-9406-0A29DD09911F}"
+          s:ds=""
+          s:par=""
+          s:ph="/page-layout/section/col-huge" />
+        <r
+          uid="{A85893F9-5DF5-4C28-AC0F-67AD85D29661}"
+          p:after="r[@uid='{565F9960-4E47-4DA4-9406-0A29DD09911F}']"
+          s:ds=""
+          s:id="{75F45B5D-2852-429B-8356-8024DEFC1640}"
+          s:par="TotalNoOfColumns=12&amp;Columns=4"
+          s:ph="/page-layout/section/col-huge" />
+      </d>
+    </r>
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "1b483e91-d8c4-4d19-ba03-462074b55936"
+      Hint: NavigationTitle
+      Value: Sitemap
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170717T071857Z
+    - ID: "c30a013f-3cc8-4961-9837-1c483277084a"
+      Hint: Title
+      Value: Sitemap
+    - ID: "ca0479ce-0bfe-4522-83de-ba688b380a78"
+      Hint: BrowserTitle
+      Value: Sitemap


### PR DESCRIPTION
I have build a feature which manage two features of Sitemap - 

1. Sitemap XML - It will generate Sitemap.XML of your site items to crawl by Google, Yahoo and other search engines. We have provided two options here either you can generate Sitemap on XML on Publishing end event or if you don't want to generate XML on every publishing we have given option to generate XML by Sitecore Scheduler. You can choose any of the option.

2. Sitemap - We have also created view renderings to show Sitemap on front end and showing two type of Sitemap - 

1. Simple Sitemap - It is basic Sitemap on the page load rendering all the items which allows by our conditions.
2. Sitemap with Expand  - This is Sitemap which provided by expand collapse feature if we have millions of item in our Site and we don't want to render them on page load because of performance then we can use this feature. On page load we are just rendering nodes which is directly inside Home Node. After that of node is having child item which are allow for Sitemap it will show a plus sign there click of plus sign we are getting all the direct children and showing them as same. 