### PR TITLE
Fix product name of Foundation.SitecoreExtensions

### DIFF
--- a/src/Foundation/SitecoreExtensions/code/Properties/AssemblyInfo.cs
+++ b/src/Foundation/SitecoreExtensions/code/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Sitecore.Feature.SitecoreExtensions")]
+[assembly: AssemblyProduct("Sitecore.Foundation.SitecoreExtensions")]
 [assembly: AssemblyCopyright("Copyright © Sitecore 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
This Foundation layer module appears to incorrectly refer to itself as a Feature layer module. This corrects the information to match the title.