### PR TITLE
Added Item level rule based personalization.

### DIFF
--- a/Habitat.sln
+++ b/Habitat.sln
@@ -1,8 +1,11 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Personalization", "Personalization", "{91FB8404-0503-480C-BCBB-B2018478FD8B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Foundation.Personalization", "src\Foundation\Personalization\code\Sitecore.Foundation.Personalization.csproj", "{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Foundation.SitecoreExtensions", "src\foundation\SitecoreExtensions\code\Sitecore.Foundation.SitecoreExtensions.csproj", "{B535703F-8D07-4F23-A533-2974BB4CC7B1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{F347A85D-6FF5-4927-B5CF-54D81954E6A2}"
@@ -205,6 +208,14 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Debug|x64.ActiveCfg = Debug|x64
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Debug|x64.Build.0 = Debug|x64
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Release|x64.ActiveCfg = Release|x64
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}.Release|x64.Build.0 = Release|x64
 		{B535703F-8D07-4F23-A533-2974BB4CC7B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B535703F-8D07-4F23-A533-2974BB4CC7B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B535703F-8D07-4F23-A533-2974BB4CC7B1}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -611,6 +622,8 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{91FB8404-0503-480C-BCBB-B2018478FD8B} = {D2CBE02E-6AA7-4343-9A01-891F971A17F5}
+		{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C} = {91FB8404-0503-480C-BCBB-B2018478FD8B}
 		{B535703F-8D07-4F23-A533-2974BB4CC7B1} = {BE813EFD-133F-4BDE-AD25-A67D16A218CA}
 		{7E46FF93-EE05-412C-AC47-2A59A13DA73C} = {4CEA4907-CB04-49A7-869D-FE39C479DF58}
 		{1AAD6F22-9B6D-4688-8EA5-1AE7044031F7} = {049C2109-CF4F-4DD1-977D-92150C924E71}

--- a/src/Foundation/Personalization/code/App_Config/Include/Foundation/Foundation.Personalization.Serialization.config
+++ b/src/Foundation/Personalization/code/App_Config/Include/Foundation/Foundation.Personalization.Serialization.config
@@ -1,0 +1,18 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+    <sitecore>
+        <unicorn>
+            <configurations>
+                <configuration name="Foundation.Personalization" description="Foundation.Personalization rules" dependencies="Foundation.Serialization,Foundation.SitecoreExtensions" extends="Helix.Foundation">
+                    <predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
+                        <include name="Personalization_Analytics_Rules" database="master" path="/sitecore/system/Settings/Analytics/Rules/Process Item" >
+                            <exclude templateId="{D9BDF22F-6E17-47F3-AB64-49C717BA92DA}" />
+                        </include>
+                        <include name="Personalization.Elements" database="master" path="/sitecore/system/Settings/Rules/Definitions/Elements/Profile Card"/>
+                        <include name="Personalization.Macro" database="master" path="/sitecore/system/Settings/Rules/Definitions/Macros/ProfileCard"/>
+                        <include name="Personalization.Tags" database="master" path="/sitecore/system/Settings/Rules/Definitions/Tags/Profile Card"/>
+                    </predicate>
+                </configuration>
+            </configurations>
+        </unicorn>
+    </sitecore>
+</configuration>

--- a/src/Foundation/Personalization/code/App_Config/Include/Foundation/Foundation.Personalization.config
+++ b/src/Foundation/Personalization/code/App_Config/Include/Foundation/Foundation.Personalization.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+    <sitecore>
+        <pipelines>
+            <processItem>
+                <processor type="Sitecore.Foundation.Personalization.Pipelines.ProcessItem.RunRules, Sitecore.Foundation.Personalization"
+                           patch:after="processor[@type='Sitecore.ExperienceExplorer.Business.Pipelines.ProcessItem.ProfilesPipeline, Sitecore.ExperienceExplorer.Business']"></processor>
+            </processItem>
+        </pipelines>
+    </sitecore>
+</configuration>

--- a/src/Foundation/Personalization/code/Constants.cs
+++ b/src/Foundation/Personalization/code/Constants.cs
@@ -1,0 +1,9 @@
+﻿namespace Sitecore.Foundation.Personalization
+{
+    using Sitecore.Data;
+
+    public static class Constants
+    {
+        public static ID ProcessItemRules = new ID("{648C8C9A-06FF-45CF-996A-5846EA68D591}");
+    }
+}

--- a/src/Foundation/Personalization/code/Pipelines/ProcessItem/RunRules.cs
+++ b/src/Foundation/Personalization/code/Pipelines/ProcessItem/RunRules.cs
@@ -1,0 +1,32 @@
+﻿namespace Sitecore.Foundation.Personalization.Pipelines.ProcessItem
+{
+    using Sitecore;
+    using Sitecore.Analytics.Pipelines.ProcessItem;
+    using Sitecore.Diagnostics;
+    using Sitecore.Rules;
+
+    public class RunRules : ProcessItemProcessor
+    {
+        public override void Process(ProcessItemArgs args)
+        {
+            Assert.ArgumentNotNull(args, "args");
+
+            var item = Context.Item;
+
+            var parentItem = item?.Database.GetItem(Personalization.Constants.ProcessItemRules);
+
+            if (parentItem == null)
+                return;
+
+            var rules = RuleFactory.GetRules<RuleContext>(parentItem, "Rule");
+            if (rules == null)
+                return;
+
+            var ruleContext = new RuleContext()
+            {
+                Item = item
+            };
+            rules.Run(ruleContext);
+        }
+    }
+}

--- a/src/Foundation/Personalization/code/Properties/AssemblyInfo.cs
+++ b/src/Foundation/Personalization/code/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sitecore.Foundation.Personalization")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sitecore.Foundation.Personalization")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f13cdc76-e69f-4f57-a03c-0e758e7b9ffc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Foundation/Personalization/code/Properties/PublishProfiles/local.pubxml
+++ b/src/Foundation/Personalization/code/Properties/PublishProfiles/local.pubxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\..\..\publishsettings.targets"/>
+  
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/src/Foundation/Personalization/code/Rules/Actions/ApplyProfileValue.cs
+++ b/src/Foundation/Personalization/code/Rules/Actions/ApplyProfileValue.cs
@@ -1,0 +1,43 @@
+﻿namespace Sitecore.Foundation.Personalization.Rules.Actions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Sitecore.Analytics;
+    using Sitecore.Analytics.Data;
+    using Sitecore.Analytics.Tracking;
+    using Sitecore.Data.Items;
+    using Sitecore.Diagnostics;
+    using Sitecore.Rules;
+    using Sitecore.Rules.Actions;
+
+    public class ApplyProfileValue<T> : RuleAction<T> where T : RuleContext
+    {
+        public string Profilecardkey { get; set; }
+
+        public override void Apply(T ruleContext)
+        {
+            Assert.ArgumentNotNull(ruleContext, "ruleContext");
+            Assert.IsNotNull(Tracker.Current.Session.Interaction, "Tracker interaction can not be null.");
+
+            var profileItem = ruleContext.Item?.Database.GetItem(this.Profilecardkey);
+            if (profileItem == null)
+                return;
+
+            ProcessProfile(profileItem, Tracker.Current.Session.Interaction);
+        }
+
+        private static void ProcessProfile(BaseItem profileItem, CurrentInteraction interaction)
+        {
+            if (profileItem?.Fields[Templates.ProfileCard.Fields.ProfileCardValue] == null) return;
+
+            var trackingFields = new List<TrackingField>
+            {
+                new TrackingField(profileItem.Fields[Templates.ProfileCard.Fields.ProfileCardValue])
+            };
+
+            var fields = (IEnumerable<TrackingField>)trackingFields;
+
+            TrackingFieldProcessor.ProcessProfiles(interaction, fields.FirstOrDefault());
+        }
+    }
+}

--- a/src/Foundation/Personalization/code/Rules/RulesMacro/ProfileCardMacro.cs
+++ b/src/Foundation/Personalization/code/Rules/RulesMacro/ProfileCardMacro.cs
@@ -1,0 +1,55 @@
+﻿namespace Sitecore.Foundation.Personalization.Rules.RulesMacro
+{
+    using System.Xml.Linq;
+    using Sitecore.Data.Items;
+    using Sitecore.Diagnostics;
+    using Sitecore.Marketing.Definitions.Profiles;
+    using Sitecore.Rules.RuleMacros;
+    using Sitecore.Shell.Applications.Dialogs.ItemLister;
+    using Sitecore.Text;
+    using Sitecore.Web.UI.Sheer;
+    using System.Linq;
+
+    public class ProfileCardMacro : IRuleMacro
+    {
+        public void Execute(XElement element, string name, UrlString parameters, string value)
+        {
+            Assert.ArgumentNotNull(element, "element");
+            Assert.ArgumentNotNull(name, "name");
+            Assert.ArgumentNotNull(parameters, "parameters");
+            Assert.ArgumentNotNull(value, "value");
+
+            if (string.IsNullOrEmpty(value)) return;
+
+            var item = Client.ContentDatabase.GetItem(value);
+            var path = XElement.Parse(element.ToString()).FirstAttribute.Value;
+
+            if (string.IsNullOrEmpty(path)) return;
+            
+            var filterItem = Client.ContentDatabase.GetItem(path);
+            if (filterItem == null) return;
+
+            var selectItemOptions = this.GetSelectItemOptions(filterItem, item);
+
+            SheerResponse.ShowModalDialog(selectItemOptions.ToUrlString().ToString(), "1200px", "700px", string.Empty, true);
+        }
+
+        private SelectItemOptions GetSelectItemOptions(Item filterItem, Item rootItem)
+        {
+            var selectItemOptions = new SelectItemOptions
+            {
+                FilterItem = filterItem,
+                Root = Client.ContentDatabase.GetItem(WellKnownIdentifiers.ProfilesContainerId),
+            };
+
+            selectItemOptions.SelectedItem = rootItem ?? selectItemOptions.Root?.Children.FirstOrDefault();
+            selectItemOptions.IncludeTemplatesForSelection = SelectItemOptions.GetTemplateList(Templates.ProfileCard.Id.ToString());
+            selectItemOptions.Title = "Select Profile Card";
+            selectItemOptions.Text = "Select the profile card to use in this rule.";
+            selectItemOptions.Icon = "Business/16x16/chart.png";
+            selectItemOptions.ShowRoot = false;
+
+            return selectItemOptions;
+        }
+    }
+}

--- a/src/Foundation/Personalization/code/Sitecore.Foundation.Personalization.csproj
+++ b/src/Foundation/Personalization/code/Sitecore.Foundation.Personalization.csproj
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8C7CFB17-C55A-40E8-BDBB-BB5A25EE299C}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sitecore.Foundation.Personalization</RootNamespace>
+    <AssemblyName>Sitecore.Foundation.Personalization</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.8.2.170614\lib\NET452\Sitecore.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.8.2.170614\lib\NET452\Sitecore.Kernel.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.NoReferences.8.2.170614\lib\NET452\Sitecore.Marketing.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="App_Config\Include\Foundation\Foundation.Personalization.Serialization.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Constants.cs" />
+    <Compile Include="Pipelines\ProcessItem\RunRules.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rules\Actions\ApplyProfileValue.cs" />
+    <Compile Include="Rules\RulesMacro\ProfileCardMacro.cs" />
+    <Compile Include="Templates.cs" />
+    <Content Include="App_Config\Include\Foundation\Foundation.Personalization.config" />
+    <Content Include="packages.config" />
+    <None Include="Properties\PublishProfiles\Local.pubxml" />
+  </ItemGroup>
+  <ItemGroup />
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>2368</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:2368/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Foundation/Personalization/code/Templates.cs
+++ b/src/Foundation/Personalization/code/Templates.cs
@@ -1,0 +1,17 @@
+﻿namespace Sitecore.Foundation.Personalization
+{
+    using Sitecore.Data;
+
+    public class Templates
+    {
+        public struct ProfileCard
+        {
+            public static ID Id = new ID("{0FC09EA4-8D87-4B0E-A5C9-8076AE863D9C}");
+
+            public struct Fields
+            {
+                public static ID ProfileCardValue = new ID("{85970AB7-22EA-4206-BE86-C0167178860B}");
+            }
+        }
+    }
+}

--- a/src/Foundation/Personalization/code/packages.config
+++ b/src/Foundation/Personalization/code/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Sitecore.Analytics.NoReferences" version="8.2.170614" targetFramework="net46" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.170614" targetFramework="net46" developmentDependency="true" />
+  <package id="Sitecore.Marketing.NoReferences" version="8.2.170614" targetFramework="net46" developmentDependency="true" />
+</packages>

--- a/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "8528843a-b84e-474c-8bf6-d231e784b4d8"
+Parent: "e7cbefe8-9112-4b95-a978-4e470d94c54a"
+Template: "54dae7cd-bfd8-4e69-9679-75f2ae9f9034"
+Path: /sitecore/system/Settings/Rules/Definitions/Elements/Profile Card
+DB: master
+SharedFields:
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{8D1DB71C-9ACF-4192-8384-5F9B6D533F95}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163208Z

--- a/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Apply Profile Value.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Apply Profile Value.yml
@@ -1,0 +1,25 @@
+﻿---
+ID: "7ea54031-bd6b-467b-bbbc-0674d086e275"
+Parent: "8528843a-b84e-474c-8bf6-d231e784b4d8"
+Template: "f90052a5-b4e6-4e6d-9812-1e1b88a6fcea"
+Path: /sitecore/system/Settings/Rules/Definitions/Elements/Profile Card/Apply Profile Value
+DB: master
+SharedFields:
+- ID: "ff55d5a7-6d4b-4cd1-83e0-bac268073f66"
+  Hint: Type
+  Value: Sitecore.Foundation.Personalization.Rules.Actions.ApplyProfileValue, Sitecore.Foundation.Personalization
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163244Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+    - ID: "eeb36a3b-40d9-4af5-862a-de257b84dca3"
+      Hint: Text
+      Value: "Apply [profilecardkey, ProfileCard,,specific] Profile Card against item"

--- a/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Tags.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Tags.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "69b66088-c221-49b0-ba47-15a8498290b1"
+Parent: "8528843a-b84e-474c-8bf6-d231e784b4d8"
+Template: "96c8e5dd-63c3-496b-a97c-a3e37e1dacba"
+Path: /sitecore/system/Settings/Rules/Definitions/Elements/Profile Card/Tags
+DB: master
+SharedFields:
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{FD4268C6-E588-4C19-B141-B1AAD488887D}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163208Z

--- a/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Tags/Default.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Tags/Default.yml
@@ -1,0 +1,22 @@
+﻿---
+ID: "5379d157-68cb-4484-8618-9d3063db2b1c"
+Parent: "69b66088-c221-49b0-ba47-15a8498290b1"
+Template: "854ba861-63ea-4a0c-8c7b-541e9a7ec4c1"
+Path: /sitecore/system/Settings/Rules/Definitions/Elements/Profile Card/Tags/Default
+DB: master
+SharedFields:
+- ID: "42f77151-098f-496a-94cf-590b7edeeabe"
+  Hint: Tags
+  Type: Multilist
+  Value: "{6084975A-488E-43ED-BE36-3765A5971DD7}"
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{6F0688E4-7B16-482F-845B-35836FD15D14}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163208Z

--- a/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Visibility.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Elements/Profile Card/Visibility.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "471ac6c0-8ee7-4ee6-8ffc-d1bde85e1a80"
+Parent: "8528843a-b84e-474c-8bf6-d231e784b4d8"
+Template: "aa91a868-02f2-41d3-8b78-1cad91b4dcae"
+Path: /sitecore/system/Settings/Rules/Definitions/Elements/Profile Card/Visibility
+DB: master
+SharedFields:
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{283F6CD6-EFB8-47AC-946A-ABB17FA45ECB}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163208Z

--- a/src/Foundation/Personalization/serialization/Personalization.Macro/ProfileCard.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Macro/ProfileCard.yml
@@ -1,0 +1,22 @@
+﻿---
+ID: "10f52cea-7c86-420e-9c4c-ef9ccb97def8"
+Parent: "083ae430-1bdd-4f4a-acf8-ecd12ed63bd2"
+Template: "40ca4912-1224-4f0b-919f-c4fe11a7a004"
+Path: /sitecore/system/Settings/Rules/Definitions/Macros/ProfileCard
+DB: master
+SharedFields:
+- ID: "e90b394e-9c00-48ff-a0ca-4e812e84b05f"
+  Hint: Type
+  Value: Sitecore.Foundation.Personalization.Rules.RulesMacro.ProfileCardMacro, Sitecore.Foundation.Personalization
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T170046Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Foundation/Personalization/serialization/Personalization.Tags/Profile Card.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Tags/Profile Card.yml
@@ -1,0 +1,22 @@
+﻿---
+ID: "6084975a-488e-43ed-be36-3765a5971dd7"
+Parent: "dadb4f93-477f-491f-a905-c4005c452e67"
+Template: "1a9b6300-4652-477c-a4b5-b2a64e86b29f"
+Path: /sitecore/system/Settings/Rules/Definitions/Tags/Profile Card
+DB: master
+SharedFields:
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{0C559214-E3B6-418E-9E1C-8AF7B19FC20B}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163527Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Foundation/Personalization/serialization/Personalization.Tags/Profile Card/Visibility.yml
+++ b/src/Foundation/Personalization/serialization/Personalization.Tags/Profile Card/Visibility.yml
@@ -1,0 +1,18 @@
+﻿---
+ID: "116fe6f9-ef54-45a6-829b-f4b151374b55"
+Parent: "6084975a-488e-43ed-be36-3765a5971dd7"
+Template: "aa91a868-02f2-41d3-8b78-1cad91b4dcae"
+Path: /sitecore/system/Settings/Rules/Definitions/Tags/Profile Card/Visibility
+DB: master
+SharedFields:
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{B1ECD86C-5B13-4698-A27A-CBE89DC12393}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T163528Z

--- a/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item.yml
+++ b/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item.yml
@@ -1,0 +1,33 @@
+﻿---
+ID: "768a0aec-ec06-4181-8a9f-f33ce3910f0a"
+Parent: "58b56416-b592-40bf-b782-98d905231dcf"
+Template: "dda66314-03f3-4c89-84a9-39dffb235b06"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item
+DB: master
+Languages:
+- Language: "de-DE"
+  Fields:
+  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+    Hint: __Display name
+    Value: Sitzungsbeginn
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170614T104313Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20100318T132654
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item/Rules.yml
+++ b/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item/Rules.yml
@@ -1,0 +1,38 @@
+﻿---
+ID: "648c8c9a-06ff-45cf-996a-5846ea68d591"
+Parent: "768a0aec-ec06-4181-8a9f-f33ce3910f0a"
+Template: "8ea2cf67-4250-47a2-aeca-4f70fd200dc7"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item/Rules
+DB: master
+SharedFields:
+- ID: "1172f251-dad4-4efb-a329-0c63500e4f1e"
+  Hint: __Masters
+  Type: TreelistEx
+  Value: "{D9BDF22F-6E17-47F3-AB64-49C717BA92DA}"
+Languages:
+- Language: "de-DE"
+  Fields:
+  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+    Hint: __Display name
+    Value: Regel
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170614T104311Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20100318T132659
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item/Tags.yml
+++ b/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item/Tags.yml
@@ -1,0 +1,33 @@
+﻿---
+ID: "f939e351-bbff-4516-a629-01b819411e45"
+Parent: "768a0aec-ec06-4181-8a9f-f33ce3910f0a"
+Template: "96c8e5dd-63c3-496b-a97c-a3e37e1dacba"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item/Tags
+DB: master
+Languages:
+- Language: "de-DE"
+  Fields:
+  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+    Hint: __Display name
+    Value: Tags
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170614T104251Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20130607T180514
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item/Tags/Default.yml
+++ b/src/Foundation/Personalization/serialization/Personalization_Analytics_Rules/Process Item/Tags/Default.yml
@@ -1,0 +1,54 @@
+﻿---
+ID: "7da6c7d5-8342-46f4-b98d-c6c88204daa7"
+Parent: "f939e351-bbff-4516-a629-01b819411e45"
+Template: "854ba861-63ea-4a0c-8c7b-541e9a7ec4c1"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item/Tags/Default
+DB: master
+SharedFields:
+- ID: "42f77151-098f-496a-94cf-590b7edeeabe"
+  Hint: Tags
+  Type: Multilist
+  Value: |
+    {7ADA27C2-E37C-4467-AC79-B91E22655C1B}
+    {83E58187-D1E5-4FB8-953E-EE89816EC0B5}
+    {2B6BE5E9-5A0B-425E-8CFF-959D7CC46581}
+    {D8933FCB-48F3-468E-8FB6-8F2B5CFAF404}
+    {09340671-13CF-4181-A706-BE150B00D735}
+    {2FC32D92-C4DC-4C63-8A5D-736F20466656}
+    {CCDEDBA3-3677-433E-BA09-64A3094808C9}
+    {B396D486-63DB-4F62-8DF1-DB0989191848}
+    {D0A59485-216D-47F5-8DFA-21C2E92D62D9}
+    {95611296-3E75-45C0-B7A4-69E69C8499AB}
+    {6C2368CA-67BE-4233-B9D7-0A0F87F09A38}
+    {ADA1A7B1-F84D-419F-96E2-77F95006DC37}
+    {5A355A23-0148-48CB-9017-90A696EAF155}
+    {9DE9BA55-DEBF-4F15-8EC1-F28FE3A5B9FD}
+    {18C2D156-9B7B-494F-ADB2-2D0D9113000E}
+    {6084975A-488E-43ED-BE36-3765A5971DD7}
+Languages:
+- Language: "de-DE"
+  Fields:
+  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+    Hint: __Display name
+    Value: Default
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170614T104251Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20130607T180500
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin

--- a/src/Project/Habitat/code/App_Config/Include/Project/Habitat.Website.Serialization.config
+++ b/src/Project/Habitat/code/App_Config/Include/Project/Habitat.Website.Serialization.config
@@ -24,6 +24,10 @@
                         <include name="Social.Applications" database="master" path="/sitecore/system/Social/Applications/Default/Habitat" />
                         <include name="Social.Klout" database="master" path="/sitecore/system/Social/Klout/Applications/Default/Habitat" />
                         <include name="Wffm.FormsLocation" database="master" path="/sitecore/system/Modules/Web Forms for Marketers/Habitat" />
+                        
+                        <include name="Rules.Feature" database="master" path="/sitecore/system/Settings/Analytics/Rules/Process Item/Rules/Feature Pages" />
+                        <include name="Rules.Foundation" database="master" path="/sitecore/system/Settings/Analytics/Rules/Process Item/Rules/Foundation Pages" />
+                        <include name="Rules.Project" database="master" path="/sitecore/system/Settings/Analytics/Rules/Process Item/Rules/Project Pages" />
                     </predicate>
                     <rolePredicate>
                         <include domain="habitat" pattern="^Project Habitat .*$" />

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix.yml
@@ -1,0 +1,22 @@
+﻿---
+ID: "a4496ed2-d4ee-4fb3-8138-882b0585fe12"
+Parent: "5411eb5c-8a94-4eae-922f-4b20f1fbe164"
+Template: "8e0c1738-3591-4c60-8151-54abcc9807d1"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix
+DB: master
+BranchID: "07624a03-bb2f-45d8-abe1-15e2b1705ff3"
+SharedFields:
+- ID: "5d9fe5d7-4c45-4a98-a1f5-4796a6da428b"
+  Hint: Name
+  Value: Helix
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{67759D75-62E4-4945-8199-913BBECD1879}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221607Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Feature.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Feature.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "cc9c33a5-eea2-420e-a80f-c0103512a5cf"
+Parent: "a4496ed2-d4ee-4fb3-8138-882b0585fe12"
+Template: "44ab5107-3c73-42f0-a427-bec549f944b9"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Feature
+DB: master
+SharedFields:
+- ID: "12e2c64a-5f08-4948-86c8-55ae06afeef8"
+  Hint: MaxValue
+  Value: 10
+- ID: "2e1a9aab-f7c1-49ee-b032-28b98d3688d6"
+  Hint: Name
+  Value: Feature
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221617Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Foundation.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Foundation.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "9e5c9674-c797-4f86-903f-5cc7e8a889ba"
+Parent: "a4496ed2-d4ee-4fb3-8138-882b0585fe12"
+Template: "44ab5107-3c73-42f0-a427-bec549f944b9"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Foundation
+DB: master
+SharedFields:
+- ID: "12e2c64a-5f08-4948-86c8-55ae06afeef8"
+  Hint: MaxValue
+  Value: 10
+- ID: "2e1a9aab-f7c1-49ee-b032-28b98d3688d6"
+  Hint: Name
+  Value: Foundation
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221624Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards.yml
@@ -1,0 +1,22 @@
+﻿---
+ID: "f54057cd-eac1-4e83-90bd-6e8169a93822"
+Parent: "a4496ed2-d4ee-4fb3-8138-882b0585fe12"
+Template: "0771b0a2-5bcf-4f87-91de-13474618b6bf"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Pattern Cards
+DB: master
+BranchID: "07624a03-bb2f-45d8-abe1-15e2b1705ff3"
+SharedFields:
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 1100
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{D7192472-9456-4B1A-AE1C-6A904200E561}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221607Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards/Feature User.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards/Feature User.yml
@@ -1,0 +1,28 @@
+﻿---
+ID: "0e4c1ab2-0ea9-4a24-83e3-e8ff1da893d0"
+Parent: "f54057cd-eac1-4e83-90bd-6e8169a93822"
+Template: "4a6a7e36-2481-438f-a9ba-0453ecc638fa"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Pattern Cards/Feature User
+DB: master
+SharedFields:
+- ID: "6da71ad3-5849-4482-9317-d21390e5a348"
+  Hint: Pattern
+  Value: |
+    <tracking>
+      <profile id="{A4496ED2-D4EE-4FB3-8138-882B0585FE12}" name="Helix">
+        <key name="Feature" value="10" />
+        <key name="Foundation" value="2" />
+        <key name="Project" value="2" />
+      </profile>
+    </tracking>
+- ID: "fe732790-2ddb-4657-a882-c2fce1fbf0c9"
+  Hint: Name
+  Value: Feature User
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221927Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards/Foundation User.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards/Foundation User.yml
@@ -1,0 +1,28 @@
+﻿---
+ID: "d888398e-ddc2-424f-a9ad-67ef590ce24d"
+Parent: "f54057cd-eac1-4e83-90bd-6e8169a93822"
+Template: "4a6a7e36-2481-438f-a9ba-0453ecc638fa"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Pattern Cards/Foundation User
+DB: master
+SharedFields:
+- ID: "6da71ad3-5849-4482-9317-d21390e5a348"
+  Hint: Pattern
+  Value: |
+    <tracking>
+      <profile id="{A4496ED2-D4EE-4FB3-8138-882B0585FE12}" name="Helix">
+        <key name="Feature" value="2" />
+        <key name="Foundation" value="10" />
+        <key name="Project" value="2" />
+      </profile>
+    </tracking>
+- ID: "fe732790-2ddb-4657-a882-c2fce1fbf0c9"
+  Hint: Name
+  Value: Foundation User
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T222015Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards/Project User.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Pattern Cards/Project User.yml
@@ -1,0 +1,28 @@
+﻿---
+ID: "25373e3e-1673-4ee9-a21e-fbde1ceb777a"
+Parent: "f54057cd-eac1-4e83-90bd-6e8169a93822"
+Template: "4a6a7e36-2481-438f-a9ba-0453ecc638fa"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Pattern Cards/Project User
+DB: master
+SharedFields:
+- ID: "6da71ad3-5849-4482-9317-d21390e5a348"
+  Hint: Pattern
+  Value: |
+    <tracking>
+      <profile id="{A4496ED2-D4EE-4FB3-8138-882B0585FE12}" name="Helix">
+        <key name="Feature" value="2" />
+        <key name="Foundation" value="2" />
+        <key name="Project" value="10" />
+      </profile>
+    </tracking>
+- ID: "fe732790-2ddb-4657-a882-c2fce1fbf0c9"
+  Hint: Name
+  Value: Project User
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T222042Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards.yml
@@ -1,0 +1,19 @@
+﻿---
+ID: "f976a8ec-6cfb-4d27-bfae-fc521eb54901"
+Parent: "a4496ed2-d4ee-4fb3-8138-882b0585fe12"
+Template: "1ad02405-7207-4962-ba96-6d6c3ba30ba7"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Profile Cards
+DB: master
+BranchID: "07624a03-bb2f-45d8-abe1-15e2b1705ff3"
+SharedFields:
+- ID: "f6d8a61c-2f84-4401-bd24-52d2068172bc"
+  Hint: __Originator
+  Value: "{8F66D1E0-DEBA-4D68-8713-DD982C1ABDE4}"
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221607Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards/Feature.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards/Feature.yml
@@ -1,0 +1,29 @@
+﻿---
+ID: "fd5d9e38-6749-410a-bafa-0a0a0b079673"
+Parent: "f976a8ec-6cfb-4d27-bfae-fc521eb54901"
+Template: "0fc09ea4-8d87-4b0e-a5c9-8076ae863d9c"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Profile Cards/Feature
+DB: master
+SharedFields:
+- ID: "85970ab7-22ea-4206-be86-c0167178860b"
+  Hint: Profile Card Value
+  Value: |
+    <tracking>
+      <profile id="{A4496ED2-D4EE-4FB3-8138-882B0585FE12}" name="Helix">
+        <key name="Feature" value="8" />
+        <key name="Foundation" value="4" />
+        <key name="Project" value="2" />
+      </profile>
+    </tracking>
+Languages:
+- Language: en
+  Fields:
+  - ID: "a26fc256-1db0-44aa-ba3d-1c830bf882a2"
+    Hint: Name
+    Value: Feature
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221651Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards/Foundation.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards/Foundation.yml
@@ -1,0 +1,29 @@
+﻿---
+ID: "9bc766ad-d936-457d-a878-b60dd00d634b"
+Parent: "f976a8ec-6cfb-4d27-bfae-fc521eb54901"
+Template: "0fc09ea4-8d87-4b0e-a5c9-8076ae863d9c"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Profile Cards/Foundation
+DB: master
+SharedFields:
+- ID: "85970ab7-22ea-4206-be86-c0167178860b"
+  Hint: Profile Card Value
+  Value: |
+    <tracking>
+      <profile id="{A4496ED2-D4EE-4FB3-8138-882B0585FE12}" name="Helix">
+        <key name="Feature" value="2" />
+        <key name="Foundation" value="8" />
+        <key name="Project" value="2" />
+      </profile>
+    </tracking>
+Languages:
+- Language: en
+  Fields:
+  - ID: "a26fc256-1db0-44aa-ba3d-1c830bf882a2"
+    Hint: Name
+    Value: Foundation
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221651Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards/Project.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Profile Cards/Project.yml
@@ -1,0 +1,29 @@
+﻿---
+ID: "55ba196f-fa85-4bc2-8545-b17c20ca5388"
+Parent: "f976a8ec-6cfb-4d27-bfae-fc521eb54901"
+Template: "0fc09ea4-8d87-4b0e-a5c9-8076ae863d9c"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Profile Cards/Project
+DB: master
+SharedFields:
+- ID: "85970ab7-22ea-4206-be86-c0167178860b"
+  Hint: Profile Card Value
+  Value: |
+    <tracking>
+      <profile id="{A4496ED2-D4EE-4FB3-8138-882B0585FE12}" name="Helix">
+        <key name="Feature" value="4" />
+        <key name="Foundation" value="4" />
+        <key name="Project" value="8" />
+      </profile>
+    </tracking>
+Languages:
+- Language: en
+  Fields:
+  - ID: "a26fc256-1db0-44aa-ba3d-1c830bf882a2"
+    Hint: Name
+    Value: Project
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221651Z

--- a/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Project.yml
+++ b/src/Project/Habitat/serialization/Profiling/Habitat/Helix/Project.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "afab03d9-4837-40af-910a-d24f9700bd22"
+Parent: "a4496ed2-d4ee-4fb3-8138-882b0585fe12"
+Template: "44ab5107-3c73-42f0-a427-bec549f944b9"
+Path: /sitecore/system/Marketing Control Panel/Profiles/Habitat/Helix/Project
+DB: master
+SharedFields:
+- ID: "12e2c64a-5f08-4948-86c8-55ae06afeef8"
+  Hint: MaxValue
+  Value: 10
+- ID: "2e1a9aab-f7c1-49ee-b032-28b98d3688d6"
+  Hint: Name
+  Value: Project
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T221632Z

--- a/src/Project/Habitat/serialization/Rules.Feature/Feature Pages.yml
+++ b/src/Project/Habitat/serialization/Rules.Feature/Feature Pages.yml
@@ -1,0 +1,39 @@
+﻿---
+ID: "e36a58bb-1311-473f-8a9d-768f8aff8478"
+Parent: "648c8c9a-06ff-45cf-996a-5846ea68d591"
+Template: "d9bdf22f-6e17-47f3-ab64-49c717ba92da"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item/Rules/Feature Pages
+DB: master
+SharedFields:
+- ID: "908ef45d-4940-4b6a-857d-3739ba4acf8f"
+  Hint: Rule
+  Type: Rules
+  Value: |
+    <ruleset>
+      <rule
+        uid="{ECFE24CA-108E-4911-817E-3D913E1FAFFF}">
+        <actions>
+          <action
+            id="{7EA54031-BD6B-467B-BBBC-0674D086E275}"
+            uid="495DA6B6F66242CD81C72EF32658CE9D"
+            profilecardkey="{FD5D9E38-6749-410A-BAFA-0A0A0B079673}" />
+        </actions>
+        <conditions>
+          <condition
+            id="{7D5DA661-BEF9-441C-B1F7-D80DE3E0972F}"
+            uid="F3609C690884400DB01BBD4ACA83E87A"
+            itemid="{F7434DF7-E32E-4F8C-A50E-27C476F4DC32}" />
+        </conditions>
+      </rule>
+    </ruleset>
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T222151Z
+    - ID: "45cf9130-802a-41be-b3eb-c02f657dcc2e"
+      Hint: Name
+      Value: Feature Pages

--- a/src/Project/Habitat/serialization/Rules.Foundation/Foundation Pages.yml
+++ b/src/Project/Habitat/serialization/Rules.Foundation/Foundation Pages.yml
@@ -1,0 +1,39 @@
+﻿---
+ID: "7373e0ec-df05-4e89-94f9-14bd5937e9b7"
+Parent: "648c8c9a-06ff-45cf-996a-5846ea68d591"
+Template: "d9bdf22f-6e17-47f3-ab64-49c717ba92da"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item/Rules/Foundation Pages
+DB: master
+SharedFields:
+- ID: "908ef45d-4940-4b6a-857d-3739ba4acf8f"
+  Hint: Rule
+  Type: Rules
+  Value: |
+    <ruleset>
+      <rule
+        uid="{03F01DD0-FEF1-455B-99D4-BB838A050E81}">
+        <conditions>
+          <condition
+            id="{7D5DA661-BEF9-441C-B1F7-D80DE3E0972F}"
+            uid="CC4EDF8080344C348E6389705A90C2FA"
+            itemid="{1A3560FC-9E54-4E65-BEAD-E349F3B80DD7}" />
+        </conditions>
+        <actions>
+          <action
+            id="{7EA54031-BD6B-467B-BBBC-0674D086E275}"
+            uid="4B3290FC90304C378A4265590FE166BF"
+            profilecardkey="{9BC766AD-D936-457D-A878-B60DD00D634B}" />
+        </actions>
+      </rule>
+    </ruleset>
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T222252Z
+    - ID: "45cf9130-802a-41be-b3eb-c02f657dcc2e"
+      Hint: Name
+      Value: Foundation Pages

--- a/src/Project/Habitat/serialization/Rules.Project/Project Pages.yml
+++ b/src/Project/Habitat/serialization/Rules.Project/Project Pages.yml
@@ -1,0 +1,39 @@
+﻿---
+ID: "dbce881e-3cf7-429c-8bf1-cd395c5e50df"
+Parent: "648c8c9a-06ff-45cf-996a-5846ea68d591"
+Template: "d9bdf22f-6e17-47f3-ab64-49c717ba92da"
+Path: /sitecore/system/Settings/Analytics/Rules/Process Item/Rules/Project Pages
+DB: master
+SharedFields:
+- ID: "908ef45d-4940-4b6a-857d-3739ba4acf8f"
+  Hint: Rule
+  Type: Rules
+  Value: |
+    <ruleset>
+      <rule
+        uid="{FE283019-8E28-44FF-BF1E-0C11E7D54E0E}">
+        <actions>
+          <action
+            id="{7EA54031-BD6B-467B-BBBC-0674D086E275}"
+            uid="C328E9A31C8B450DAB83A7E9ED1ADEB0"
+            profilecardkey="{55BA196F-FA85-4BC2-8545-B17C20CA5388}" />
+        </actions>
+        <conditions>
+          <condition
+            id="{7D5DA661-BEF9-441C-B1F7-D80DE3E0972F}"
+            uid="32090B39D5354C569556275533A5AEC9"
+            itemid="{8D8EDB18-B641-4277-BAD3-9C6CF89F9FE3}" />
+        </conditions>
+      </rule>
+    </ruleset>
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170806T222342Z
+    - ID: "45cf9130-802a-41be-b3eb-c02f657dcc2e"
+      Hint: Name
+      Value: Project Pages


### PR DESCRIPTION
This is new functionality to extended the processItem pipeline allowing rules to control how profile cards are applied to items. Instead of adding them to items directly, to templates or through standard values.

Here is a video demonstrating the functionality on the pull request. You will probably want to download the video since drop box's video player isn't very clear.
https://www.dropbox.com/s/y1g701nf0lv7gjw/Habitat%20Profile%20Rules%20Engine.mp4?dl=0

