### PR TITLE
Update gulp-sass to fix npm install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-newer": "^1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-rimraf": "^0.2.0",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^3.1.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
Fixes #333 
Error caused by old `node-sass` module dependency