### PR TITLE
Quantus library integration added

### DIFF
--- a/src/Feature/Search/code/Views/Search/SearchResultsHeader.cshtml
+++ b/src/Feature/Search/code/Views/Search/SearchResultsHeader.cshtml
@@ -20,7 +20,7 @@
         else
         {
             <h1 class="text-center">
-                @string.Format(Html.Sitecore().Dictionary("/search/header/Title With Results", "Your search for '{0}' yielded '{1}' results:"), Model.Context.Query, totalResults)
+                @string.Format(Html.Sitecore().DictionaryPlural("/search/header/Title With Results", totalResults, "Your search for '{0}' yielded '{1}' results:"), Model.Context.Query, totalResults)
             </h1>
         }
     }

--- a/src/Foundation/Dictionary/code/App_Config/Include/Quantus.config
+++ b/src/Foundation/Dictionary/code/App_Config/Include/Quantus.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+    <sitecore>
+        <quantus>
+            <patch:attribute name="defaultProvider">fallback</patch:attribute>
+            <providers>
+                <add name="fallback" type="Quantus.Providers.OtherPluralProvider, Quantus" />
+                
+                <add name="da" type="Quantus.Providers.DanishPluralProvider, Quantus" />
+                <add name="de" type="Quantus.Providers.GermanPluralProvider, Quantus" />
+                <add name="en" type="Quantus.Providers.EnglishPluralProvider, Quantus" />
+                <add name="fr" type="Quantus.Providers.FrenchPluralProvider, Quantus" />
+                <add name="ja" type="Quantus.Providers.JapanesePluralProvider, Quantus" />
+                <add name="pl" type="Quantus.Providers.PolishPluralProvider, Quantus" />
+            </providers>
+        </quantus>
+    </sitecore>
+</configuration>

--- a/src/Foundation/Dictionary/code/Extensions/SitecoreExtensions.cs
+++ b/src/Foundation/Dictionary/code/Extensions/SitecoreExtensions.cs
@@ -4,6 +4,9 @@
   using Sitecore.Foundation.Dictionary.Repositories;
   using Sitecore.Foundation.SitecoreExtensions.Extensions;
   using Sitecore.Mvc.Helpers;
+  using Quantus;
+  using Quantus.Sitecore.Services;
+  using Sitecore.Data;
 
   public static class SitecoreExtensions
   {
@@ -18,6 +21,46 @@
       if (item == null)
         return new HtmlString(defaultValue);
       return helper.Field(Templates.DictionaryEntry.Fields.Phrase, item);
+    }
+
+    public static string DictionaryPlural(this SitecoreHelper helper, string relativePath, decimal quantity, string defaultValue = "")
+    {
+      var category = PluralService.GetPluralCategory(Context.Language.Name, quantity);
+      var fieldId = GetPluralFieldId(category);
+
+      return DictionaryPhraseRepository.Current.GetPlural(relativePath, fieldId, defaultValue);
+    }
+
+    public static HtmlString DictionaryPluralField(this SitecoreHelper helper, string relativePath, decimal quantity, string defaultValue = "")
+    {
+      var item = DictionaryPhraseRepository.Current.GetPluralItem(relativePath, defaultValue);
+      if (item == null)
+        return new HtmlString(defaultValue);
+
+      var type = PluralService.GetPluralCategory(Context.Language.Name, quantity);
+      var fieldId = GetPluralFieldId(type);
+
+      return helper.Field(fieldId, item);
+    }
+
+    private static ID GetPluralFieldId(PluralCategory category)
+    {
+      switch (category)
+      {
+        case PluralCategory.Zero:
+            return Templates.DictionaryPluralEntry.Fields.PhraseZero;
+        case PluralCategory.One:
+            return Templates.DictionaryPluralEntry.Fields.PhraseOne;
+        case PluralCategory.Two:
+            return Templates.DictionaryPluralEntry.Fields.PhraseTwo;
+        case PluralCategory.Few:
+            return Templates.DictionaryPluralEntry.Fields.PhraseFew;
+        case PluralCategory.Many:
+            return Templates.DictionaryPluralEntry.Fields.PhraseMany;
+        case PluralCategory.Other:
+        default:
+            return Templates.DictionaryPluralEntry.Fields.PhraseOther;
+      }
     }
   }
 }

--- a/src/Foundation/Dictionary/code/Repositories/DictionaryPhraseRepository.cs
+++ b/src/Foundation/Dictionary/code/Repositories/DictionaryPhraseRepository.cs
@@ -42,6 +42,16 @@
 
     public string Get([NotNull] string relativePath, string defaultValue)
     {
+      return this.Get(relativePath, Templates.DictionaryEntry.Fields.Phrase, false, defaultValue);
+    }
+
+    public string GetPlural([NotNull] string relativePath, ID fieldId, string defaultValue = "")
+    {
+      return this.Get(relativePath, fieldId, true, defaultValue);
+    }
+
+    private string Get([NotNull] string relativePath, ID fieldId, bool plural, string defaultValue)
+    {
       if (relativePath == null)
       {
         throw new ArgumentNullException(nameof(relativePath));
@@ -51,23 +61,33 @@
         return defaultValue;
       }
 
-      var dictionaryItem = this.GetOrAutoCreateItem(relativePath, defaultValue);
+      var dictionaryItem = this.GetOrAutoCreateItem(relativePath, plural, defaultValue);
       if (dictionaryItem == null)
       {
         return defaultValue;
       }
 
-      return dictionaryItem.Fields[Templates.DictionaryEntry.Fields.Phrase].Value ?? defaultValue;
+      return dictionaryItem.Fields[fieldId].Value ?? defaultValue;
     }
 
     public Item GetItem([NotNull] string relativePath, string defaultValue = "")
+    {
+        return this.GetItem(relativePath, false, defaultValue);
+    }
+
+    public Item GetPluralItem([NotNull] string relativePath, string defaultValue = "")
+    {
+        return this.GetItem(relativePath, true, defaultValue);
+    }
+
+    private Item GetItem([NotNull] string relativePath, bool plural, string defaultValue = "")
     {
       if (relativePath == null)
       {
         throw new ArgumentNullException(nameof(relativePath));
       }
 
-      var item = this.GetOrAutoCreateItem(relativePath, defaultValue);
+      var item = this.GetOrAutoCreateItem(relativePath, plural, defaultValue);
       if (item == null)
       {
         Log.Debug($"Could not find the dictionary item for the site '{this.Dictionary.Site.Name}' with the path '{relativePath}'", this);
@@ -75,7 +95,7 @@
       return item;
     }
 
-    private Item GetOrAutoCreateItem([NotNull]string relativePath, [CanBeNull]string defaultValue)
+    private Item GetOrAutoCreateItem([NotNull]string relativePath, bool plural, [CanBeNull]string defaultValue)
     {
       relativePath = AssertRelativePath(relativePath);
 
@@ -87,7 +107,7 @@
         return null;
       try
       {
-        return CreateDictionaryEntryService.CreateDictionaryEntry(this.Dictionary, relativePath, defaultValue);
+        return CreateDictionaryEntryService.CreateDictionaryEntry(this.Dictionary, relativePath, plural, defaultValue);
       }
       catch (Exception ex)
       {

--- a/src/Foundation/Dictionary/code/Repositories/IDictionaryPhraseRepository.cs
+++ b/src/Foundation/Dictionary/code/Repositories/IDictionaryPhraseRepository.cs
@@ -1,10 +1,13 @@
-﻿using Sitecore.Data.Items;
+﻿using Sitecore.Data;
+using Sitecore.Data.Items;
 
 namespace Sitecore.Foundation.Dictionary.Repositories
 {
   public interface IDictionaryPhraseRepository
   {
     string Get(string relativePath, string defaultValue = "");
+    string GetPlural(string relativePath, ID fieldId, string defaultValue = "");
     Item GetItem(string relativePath, string defaultValue = "");
+    Item GetPluralItem(string relativePath, string defaultValue = "");
   }
 }

--- a/src/Foundation/Dictionary/code/Services/CreateDictionaryEntryService.cs
+++ b/src/Foundation/Dictionary/code/Services/CreateDictionaryEntryService.cs
@@ -10,7 +10,7 @@
 
     internal static class CreateDictionaryEntryService
     {
-        public static Item CreateDictionaryEntry(Dictionary dictionary, string relativePath, string defaultValue)
+        public static Item CreateDictionaryEntry(Dictionary dictionary, string relativePath, bool plural, string defaultValue)
         {
             lock (dictionary)
             {
@@ -20,18 +20,18 @@
                 {
                     root = CreateDictionaryFolder(parts[i], root);
                 }
-                return CreateDictionaryEntry(parts.Last(), root, defaultValue);
+                return CreateDictionaryEntry(parts.Last(), root, plural, defaultValue);
             }
         }
 
-        private static Item CreateDictionaryEntry(string name, Item root, string defaultValue)
+        private static Item CreateDictionaryEntry(string name, Item root, bool plural, string defaultValue)
         {
             using (new SecurityDisabler())
             {
-                var item = GetOrCreateDictionaryItem(name, root, Templates.DictionaryEntry.ID);
+                var item = GetOrCreateDictionaryItem(name, root, plural ? Templates.DictionaryPluralEntry.ID : Templates.DictionaryEntry.ID);
                 using (new EditContext(item))
                 {
-                    item[Templates.DictionaryEntry.Fields.Phrase] = defaultValue;
+                    item[plural ? Templates.DictionaryPluralEntry.Fields.PhraseOther : Templates.DictionaryEntry.Fields.Phrase] = defaultValue;
                 }
                 return item;
             }

--- a/src/Foundation/Dictionary/code/Sitecore.Foundation.Dictionary.csproj
+++ b/src/Foundation/Dictionary/code/Sitecore.Foundation.Dictionary.csproj
@@ -55,6 +55,12 @@
       <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Quantus, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Quantus.1.0.1\lib\net452\Quantus.dll</HintPath>
+    </Reference>
+    <Reference Include="Quantus.Sitecore, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Quantus.Sitecore.1.0.1\lib\net452\Quantus.Sitecore.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.8.2.170614\lib\NET452\Sitecore.Kernel.dll</HintPath>
     </Reference>
@@ -105,6 +111,7 @@
     <Content Include="App_Config\Include\Foundation\Foundation.Dictionary.config" />
     <Content Include="App_Config\Include\Foundation\Foundation.Dictionary.Serialization.config" />
     <Content Include="packages.config" />
+    <Content Include="App_Config\Include\Quantus.config" />
     <None Include="Properties\PublishProfiles\Local.pubxml" />
     <None Include="Web.config" />
   </ItemGroup>

--- a/src/Foundation/Dictionary/code/Templates.cs
+++ b/src/Foundation/Dictionary/code/Templates.cs
@@ -18,6 +18,20 @@
       }
     }
 
+    public struct DictionaryPluralEntry
+    {
+      public static ID ID => new ID("{EA8709B5-ADDD-4179-9F54-40D709421EFF}");
+      public struct Fields
+      {
+        public static ID PhraseZero => new ID("{75C574D7-9FBA-4DFD-BE5B-5405655DAF12}");
+        public static ID PhraseOne => new ID("{BC70DEBF-7886-4835-9A65-D3276A098F03}");
+        public static ID PhraseTwo => new ID("{37D72E7F-BA96-4275-AA13-122218894060}");
+        public static ID PhraseFew => new ID("{E4200F91-B221-4F82-A9E6-C0B1FEFE1BA5}");
+        public static ID PhraseMany => new ID("{AA1AB933-15B6-42AE-B6C5-86225CE23A24}");
+        public static ID PhraseOther => new ID("{3FAA1728-51C9-44EE-8AF3-73F1E856A1E9}");
+      }
+    }
+
     public struct DictionarySettings
     {
       public static ID ID => new ID("{31D191DD-3FA1-4D2F-A348-7F315F72279F}");

--- a/src/Foundation/Dictionary/code/packages.config
+++ b/src/Foundation/Dictionary/code/packages.config
@@ -6,6 +6,8 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
+  <package id="Quantus" version="1.0.1" targetFramework="net46" />
+  <package id="Quantus.Sitecore" version="1.0.1" targetFramework="net46" />
   <package id="Sitecore.Kernel.NoReferences" version="8.2.170614" targetFramework="net46" developmentDependency="true" />
   <package id="Sitecore.Mvc.NoReferences" version="8.2.170614" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry.yml
@@ -1,0 +1,45 @@
+﻿---
+ID: "ea8709b5-addd-4179-9f54-40d709421eff"
+Parent: "4b333e08-bbb7-48ad-8150-8203be0cb77c"
+Template: "ab86861a-6030-46c5-b394-e8f99e8b87db"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry
+DB: master
+SharedFields:
+- ID: "06d5295c-ed2f-4a54-9bf2-26228d113318"
+  Hint: __Icon
+  Value: WordProcessing/32x32/footer_h.png
+- ID: "12c33f3f-86c5-43a5-aeb4-5598cec45116"
+  Hint: __Base template
+  Type: tree list
+  Value: "{1930BBEB-7805-471A-A3BE-4858AC7CF696}"
+- ID: "61cf7151-0cbd-4db4-9738-d753a55a6e65"
+  Hint: __Enforce version presence
+  Type: Checkbox
+  Value: 1
+- ID: "fd4e2050-186c-4375-8b99-e8a85dd7436e"
+  Hint: __Enable item fallback
+  Type: Checkbox
+  Value: 1
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160405T225051Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: "ja-JP"
+  Fields:
+  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+    Hint: __Display name
+    Value: 辞書のエントリー
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: "20170323T054833:636258449134266804Z"

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary.yml
@@ -1,0 +1,33 @@
+﻿---
+ID: "49749df5-e147-4426-a405-474dc45b9bdb"
+Parent: "ea8709b5-addd-4179-9f54-40d709421eff"
+Template: "e269fbb5-3750-427a-9149-7aa950b49301"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary
+DB: master
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160405T225512Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\admin
+- Language: "ja-JP"
+  Fields:
+  - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
+    Hint: __Display name
+    Value: 辞書
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170323T054833Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\Admin

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Few.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Few.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "e4200f91-b221-4f82-a9e6-c0b1fefe1ba5"
+Parent: "49749df5-e147-4426-a405-474dc45b9bdb"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Few
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 400
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20171107T221756Z

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Many.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Many.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "aa1ab933-15b6-42ae-b6c5-86225ce23a24"
+Parent: "49749df5-e147-4426-a405-474dc45b9bdb"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Many
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 500
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20171107T221756Z

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase One.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase One.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "bc70debf-7886-4835-9a65-d3276a098f03"
+Parent: "49749df5-e147-4426-a405-474dc45b9bdb"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary/Phrase One
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 200
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20171107T221755Z

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Other.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Other.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "3faa1728-51c9-44ee-8af3-73f1e856a1e9"
+Parent: "49749df5-e147-4426-a405-474dc45b9bdb"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Other
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 600
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20171107T221756Z

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Two.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Two.yml
@@ -1,0 +1,21 @@
+﻿---
+ID: "37d72e7f-ba96-4275-aa13-122218894060"
+Parent: "49749df5-e147-4426-a405-474dc45b9bdb"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Two
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 300
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20171107T221756Z

--- a/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Zero.yml
+++ b/src/Foundation/Dictionary/serialization/Templates/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Zero.yml
@@ -1,0 +1,36 @@
+﻿---
+ID: "75c574d7-9fba-4dfd-be5b-5405655daf12"
+Parent: "49749df5-e147-4426-a405-474dc45b9bdb"
+Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
+Path: /sitecore/templates/Foundation/Dictionary/DictionaryPluralEntry/Dictionary/Phrase Zero
+DB: master
+SharedFields:
+- ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
+  Hint: Type
+  Value: "Single-Line Text"
+- ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
+  Hint: __Sortorder
+  Value: 100
+Languages:
+- Language: en
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20160405T225512Z
+- Language: "ja-JP"
+  Fields:
+  - ID: "19a69332-a23e-4e70-8d16-b2640cb24cc8"
+    Hint: Title
+    Value: 用語
+  Versions:
+  - Version: 1
+    Fields:
+    - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
+      Hint: __Created
+      Value: 20170323T054833Z
+    - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
+      Hint: __Created by
+      Value: |
+        sitecore\Admin

--- a/src/Foundation/Dictionary/tests/Repositories/DictionaryPhraseRepositoryTests.cs
+++ b/src/Foundation/Dictionary/tests/Repositories/DictionaryPhraseRepositoryTests.cs
@@ -26,6 +26,14 @@
 
         [Theory]
         [AutoDbData]
+        public void GetPlural_NullRElativePath_ThrowArgumentNullException(string defaultValue)
+        {
+            var repository = new DictionaryPhraseRepository(new Dictionary());
+            repository.Invoking(x => x.GetPlural(null, Templates.DictionaryPluralEntry.Fields.PhraseOther, defaultValue)).ShouldThrow<ArgumentNullException>();
+        }
+
+        [Theory]
+        [AutoDbData]
         public void Get_DatabaseIsNull_ReturnDefaultValue(string relativePath, string defaultValue)
         {
             //Arrange
@@ -41,6 +49,21 @@
 
         [Theory]
         [AutoDbData]
+        public void GetPlural_DatabaseIsNull_ReturnDefaultValue(string relativePath, string defaultValue)
+        {
+            //Arrange
+            Context.Database = null;
+            var repository = new DictionaryPhraseRepository(new Dictionary());
+
+            //Act
+            var result = repository.GetPlural(relativePath, Templates.DictionaryPluralEntry.Fields.PhraseOther, defaultValue);
+
+            //Assert
+            result.Should().Be(defaultValue);
+        }
+
+        [Theory]
+        [AutoDbData]
         public void Get_AutocreateIsFalseEntryDoesntExists_ReturnDefaultValue(Db db, [Content] Item rootItem, string relativePath, string defaultValue)
         {
             //Arrange
@@ -48,6 +71,20 @@
 
             //Act
             var result = repository.Get(relativePath, defaultValue);
+
+            //Assert
+            result.Should().Be(defaultValue);
+        }
+
+        [Theory]
+        [AutoDbData]
+        public void GetPlural_AutocreateIsFalseEntryDoesntExists_ReturnDefaultValue(Db db, [Content] Item rootItem, string relativePath, string defaultValue)
+        {
+            //Arrange
+            var repository = new DictionaryPhraseRepository(new Dictionary { Root = rootItem, AutoCreate = false });
+
+            //Act
+            var result = repository.GetPlural(relativePath, Templates.DictionaryPluralEntry.Fields.PhraseOther, defaultValue);
 
             //Assert
             result.Should().Be(defaultValue);
@@ -72,10 +109,35 @@
 
         [Theory]
         [AutoDbData]
+        public void GetPlural_AutocreateIsTrueEntryDoesntExists_ShouldCreateItem(Db db, [Content] CreateDictionaryEntryServiceTests.DictionaryPluralEntryTemplate entryTemplate, [Content] Item rootItem, IEnumerable<string> pathParts, string defaultValue)
+        {
+            //Arrange
+            var relativePath = string.Join("/", pathParts.Select(ItemUtil.ProposeValidItemName));
+            var repository = new DictionaryPhraseRepository(new Dictionary { Root = rootItem, AutoCreate = true });
+            db.Add(new DbTemplate(Templates.DictionaryFolder.ID));
+
+            //Act
+            var result = repository.GetPlural(relativePath, Templates.DictionaryPluralEntry.Fields.PhraseOther, defaultValue);
+
+            //Assert
+            result.Should().Be(defaultValue);
+            rootItem.Axes.GetItem(relativePath).Should().NotBeNull();
+        }
+
+        [Theory]
+        [AutoDbData]
         public void GetItem_NullRElativePath_ThrowArgumentNullException(string defaultValue)
         {
             var repository = new DictionaryPhraseRepository(new Dictionary());
             repository.Invoking(x => x.GetItem(null, defaultValue)).ShouldThrow<ArgumentNullException>();
+        }
+
+        [Theory]
+        [AutoDbData]
+        public void GetPluralItem_NullRElativePath_ThrowArgumentNullException(string defaultValue)
+        {
+            var repository = new DictionaryPhraseRepository(new Dictionary());
+            repository.Invoking(x => x.GetPluralItem(null, defaultValue)).ShouldThrow<ArgumentNullException>();
         }
 
         [Theory]
@@ -87,6 +149,20 @@
 
             //Act
             var result = repository.GetItem(relativePath, defaultValue);
+
+            //Assert
+            result.Should().BeNull();
+        }
+
+        [Theory]
+        [AutoDbData]
+        public void GetPluralItem_AutocreateIsFalseEntryDoesntExists_ReturnNull(Db db, [Content] Item rootItem, string relativePath, string defaultValue)
+        {
+            //Arrange
+            var repository = new DictionaryPhraseRepository(new Dictionary { Root = rootItem, AutoCreate = false, Site = new FakeSiteContext("test") });
+
+            //Act
+            var result = repository.GetPluralItem(relativePath, defaultValue);
 
             //Assert
             result.Should().BeNull();
@@ -110,6 +186,22 @@
 
         [Theory]
         [AutoDbData]
+        public void GetPlural_AutocreateIsTrueEntryDoesntExists_ShouldreturnItem(Db db, [Content] CreateDictionaryEntryServiceTests.DictionaryPluralEntryTemplate entryTemplate, [Content] Item rootItem, IEnumerable<string> pathParts, string defaultValue)
+        {
+            //Arrange
+            var relativePath = string.Join("/", pathParts.Select(ItemUtil.ProposeValidItemName));
+            var repository = new DictionaryPhraseRepository(new Dictionary { Root = rootItem, AutoCreate = true });
+            db.Add(new DbTemplate(Templates.DictionaryFolder.ID));
+
+            //Act
+            var result = repository.GetPluralItem(relativePath, defaultValue);
+
+            //Assert
+            result[Templates.DictionaryPluralEntry.Fields.PhraseOther].Should().Be(defaultValue);
+        }
+
+        [Theory]
+        [AutoDbData]
         public void Get_IncorrectRelativePath_ThrowArgumentException(Db db, [Content] Item rootItem, string defaultValue)
         {
             //Arrange
@@ -118,6 +210,18 @@
 
             //Assert
             repository.Invoking(x => x.Get(relativePath, defaultValue)).ShouldThrow<ArgumentException>();
+        }
+
+        [Theory]
+        [AutoDbData]
+        public void GetPlural_IncorrectRelativePath_ThrowArgumentException(Db db, [Content] Item rootItem, string defaultValue)
+        {
+            //Arrange
+            var relativePath = "/";
+            var repository = new DictionaryPhraseRepository(new Dictionary { Root = rootItem, AutoCreate = true });
+
+            //Assert
+            repository.Invoking(x => x.GetPlural(relativePath, Templates.DictionaryPluralEntry.Fields.PhraseOther, defaultValue)).ShouldThrow<ArgumentException>();
         }
     }
 }

--- a/src/Foundation/Dictionary/tests/Services/CreateDictionaryEntryServiceTests.cs
+++ b/src/Foundation/Dictionary/tests/Services/CreateDictionaryEntryServiceTests.cs
@@ -15,7 +15,7 @@
     {
         [Theory]
         [AutoDbData]
-        public void CreateDictionaryEntry_Call_CreateItems(Db db, [Content] DictionaryEntryTemplate entryTemplate, [Content] DbItem rootItem, IEnumerable<string> pathParts, string defaultValue)
+        public void CreateDictionaryEntry_Call_CreateItems(Db db, [Content] DictionaryEntryTemplate entryTemplate, [Content] DictionaryPluralEntryTemplate pluralEntryTemplate, [Content] DbItem rootItem, IEnumerable<string> pathParts, IEnumerable<string> pluralPathParts, string defaultValue)
         {
             //Arrange
             var dictionary = new Dictionary
@@ -24,15 +24,22 @@
             };
             db.Add(new DbTemplate(Templates.DictionaryFolder.ID));
             var path = string.Join("/", pathParts.Select(ItemUtil.ProposeValidItemName));
+            var pluralPath = string.Join("/", pluralPathParts.Select(ItemUtil.ProposeValidItemName));
 
             //Act
-            var phraseItem = CreateDictionaryEntryService.CreateDictionaryEntry(dictionary, path, defaultValue);
+            var phraseItem = CreateDictionaryEntryService.CreateDictionaryEntry(dictionary, path, false, defaultValue);
+            var pluralPhraseItem = CreateDictionaryEntryService.CreateDictionaryEntry(dictionary, pluralPath, true, defaultValue);
 
             //Assert
             phraseItem.Should().NotBeNull();
             phraseItem.TemplateID.Should().Be(Templates.DictionaryEntry.ID);
             phraseItem.Paths.FullPath.Should().Be($"{rootItem.FullPath}/{path}");
             phraseItem[Templates.DictionaryEntry.Fields.Phrase].Should().Be(defaultValue);
+
+            pluralPhraseItem.Should().NotBeNull();
+            pluralPhraseItem.TemplateID.Should().Be(Templates.DictionaryPluralEntry.ID);
+            pluralPhraseItem.Paths.FullPath.Should().Be($"{rootItem.FullPath}/{pluralPath}");
+            pluralPhraseItem[Templates.DictionaryPluralEntry.Fields.PhraseOther].Should().Be(defaultValue);
         }
 
         public class DictionaryEntryTemplate : DbTemplate
@@ -40,6 +47,14 @@
             public DictionaryEntryTemplate() : base(Templates.DictionaryEntry.ID)
             {
                 this.Add(Templates.DictionaryEntry.Fields.Phrase);
+            }
+        }
+
+        public class DictionaryPluralEntryTemplate : DbTemplate
+        {
+            public DictionaryPluralEntryTemplate() : base(Templates.DictionaryPluralEntry.ID)
+            {
+                this.Add(Templates.DictionaryPluralEntry.Fields.PhraseOther);
             }
         }
     }

--- a/src/Project/Habitat/serialization/Content/Habitat/Global/Dictionary/Search/Header/Title With Results.yml
+++ b/src/Project/Habitat/serialization/Content/Habitat/Global/Dictionary/Search/Header/Title With Results.yml
@@ -1,7 +1,7 @@
 ﻿---
 ID: "2d021632-5542-41de-8689-1574c0e9fc39"
 Parent: "39eaf748-83bc-43bd-a839-877d2f85d095"
-Template: "ec4dd3f2-590d-404b-9189-2a12679749cc"
+Template: "ea8709b5-addd-4179-9f54-40d709421eff"
 Path: /sitecore/content/Habitat/Global/Dictionary/Search/Header/Title With Results
 DB: master
 Languages:
@@ -12,10 +12,16 @@ Languages:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20160406T234440Z
+    - ID: "3faa1728-51c9-44ee-8af3-73f1e856a1e9"
+      Hint: Phrase Other
+      Value: "Your search for '{0}' yielded {1} results:"
     - ID: "5dd74568-4d4b-44c1-b513-0af5f4cda34f"
       Hint: __Created by
       Value: |
         extranet\Anonymous
+    - ID: "bc70debf-7886-4835-9a65-d3276a098f03"
+      Hint: Phrase One
+      Value: "Your search for '{0}' yielded {1} result:"
     - ID: "ddacdd55-5b08-405f-9e58-04f09aed640a"
       Hint: Phrase
       Value: "Your search for '{0}' yielded {1} results:"


### PR DESCRIPTION
Hi, I wrote Quantus library and decided to integrate it with Habitat. You can read more about the library here: [Quantus](https://github.com/bartlomiejmucha/Quantus/blob/master/README.md) and here: [Quantus.Sitecore](https://github.com/bartlomiejmucha/Quantus/blob/master/README.md)
There will be also a blog post about it soon here: [bartlomiejmucha.com](http://bartlomiejmucha.com)

In this pull request:
* I installed Quantus and Quantus.Sitecore NuGet packages,
* I created new DictionaryPluralEntry template,
* I created helper methods in SitecoreExtensions class,
* I also changed existing dictionary item (/search/header/Title With Results) to use DictionaryPluralEntry template,
* Then I updated SearchResultHeader.cshtml view to use plural entry.