### PR TITLE
Fix dependency validation issue when only JRE (and not JDK) is installed

### DIFF
--- a/build/assets/readme.txt
+++ b/build/assets/readme.txt
@@ -1,1 +1,14 @@
-Add asset files to this directory
+Add asset files to this directory. You will need:
+
+- license.xml (your Sitecore license)
+- Sitecore 9 OnPrem WDP packages, e.g.
+	Sitecore 9.0.0 rev. 171002 (OnPrem)_single.scwdp.zip
+	Sitecore 9.0.0 rev. 171002 (OnPrem)_xp0xconnect.scwdp.zip
+- from the XP0 config files that come with the OnPrem WDP packages:
+	xconnect-solr.json
+	xconnect-createcert.json
+	xconnect-xp0.json
+	sitecore-solr.json
+	sitecore-xp0.json
+
+See the documentation for more details.

--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -96,6 +96,7 @@ function Install-Prerequisites {
     }
 
     # Verify Solr
+    Write-Host "Verifying Solr connection" -ForegroundColor Green
     if (-not $SolrUrl.ToLower().StartsWith("https")) {
         throw "Solr URL ($SolrUrl) must be secured with https"
     }
@@ -108,8 +109,20 @@ function Install-Prerequisites {
 	}
 	finally {
 		$SolrResponse.Close()
-	}
-	
+    }
+    
+    Write-Host "Verifying Solr directory" -ForegroundColor Green
+    if(-not (Test-Path "$SolrRoot\server")) {
+        throw "The Solr root path '$SolrRoot' appears invalid. A 'server' folder should be present in this path to be a valid Solr distributive."
+    }
+
+    Write-Host "Verifying Solr service" -ForegroundColor Green
+    try {
+        $null = Get-Service $SolrService
+    } catch {
+        throw "The Solr service '$SolrService' does not exist. Perhaps it's incorrect in settings.ps1?"
+    }
+
 	#Verify .NET framework
 	$requiredDotNetFrameworkVersionValue = 394802
 	$requiredDotNetFrameworkVersion = "4.6.2"

--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -30,7 +30,7 @@ function Install-Prerequisites {
 	if (Test-Path $jrePath) {
 		$path = $jrePath
 	}
-	if (Test-Path $jdkPath) {
+	elseif (Test-Path $jdkPath) {
 		$path = $jdkPath
 	}
 	else {

--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -3,6 +3,8 @@
 #  Install Sitecore
 # 
 #####################################################
+$ErrorActionPreference = 'Stop'
+
 . $PSScriptRoot\settings.ps1
 
 Write-Host "*******************************************************" -ForegroundColor Green

--- a/uninstall-xp0.ps1
+++ b/uninstall-xp0.ps1
@@ -15,6 +15,14 @@ Write-Host "*******************************************************" -Foreground
 if (Get-Module("uninstall")) {
     Remove-Module "uninstall"
 }
+
+$carbon = Get-Module Carbon
+if (-not $carbon) {
+    write-host "Installing Carbon..." -ForegroundColor Green
+    Install-Module -Name 'Carbon' -AllowClobber -Scope CurrentUser
+    Import-Module Carbon
+}
+
 Import-Module "$PSScriptRoot\build\uninstall\uninstall.psm1"
 
 $database = Get-SitecoreDatabase -SqlServer $SqlServer -SqlAdminUser $SqlAdminUser -SqlAdminPassword $SqlAdminPassword


### PR DESCRIPTION
When only the JRE (and not the JDK) is installed, the dependency validation fails. This fixes that.

Additional fixes have also been made to improve reliability and reduce errors, especially around Solr, based on setting Habitat up on a fresh computer that just had Solr + IIS. See commits for details.