### PR TITLE
Remove dependency on static context in site extensions

### DIFF
--- a/src/Foundation/SitecoreExtensions/code/Extensions/SiteExtensions.cs
+++ b/src/Foundation/SitecoreExtensions/code/Extensions/SiteExtensions.cs
@@ -24,7 +24,7 @@
       if (site == null)
         throw new ArgumentNullException(nameof(site));
 
-      return site.Database.GetItem(Context.Site.RootPath);
+      return site.Database.GetItem(site.RootPath);
     }
 
     public static Item GetStartItem(this SiteContext site)
@@ -32,7 +32,7 @@
       if (site == null)
         throw new ArgumentNullException(nameof(site));
 
-      return site.Database.GetItem(Context.Site.StartPath);
+      return site.Database.GetItem(site.StartPath);
     }
   }
 }


### PR DESCRIPTION
Removed the dependency on the static Sitecore Context. It may trigger weird behavior when working with multiple sites since the site passed to the extension may not be the Context.Site.