### PR TITLE
Add Nuget references

### DIFF
--- a/src/Feature/Accounts/code/Sitecore.Feature.Accounts.csproj
+++ b/src/Feature/Accounts/code/Sitecore.Feature.Accounts.csproj
@@ -79,42 +79,35 @@
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Model.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Owin">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Owin.dll</HintPath>
+    <Reference Include="Sitecore.Owin, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Owin.NoReferences.9.0.171219\lib\NET462\Sitecore.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Owin.Authentication">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Owin.Authentication.dll</HintPath>
+    <Reference Include="Sitecore.Owin.Authentication, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Owin.Authentication.NoReferences.9.0.171219\lib\NET462\Sitecore.Owin.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Client.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Client.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect.Client.Configuration, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Client.Configuration.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.Configuration.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Client.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Collection.Model">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Collection.Model.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Collection.Model, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Collection.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Collection.Model.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />

--- a/src/Feature/Accounts/code/Web.config
+++ b/src/Feature/Accounts/code/Web.config
@@ -67,6 +67,14 @@
                 <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" xmlns="urn:schemas-microsoft-com:asm.v1" />
                 <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Accounts/code/packages.config
+++ b/src/Feature/Accounts/code/packages.config
@@ -17,6 +17,16 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Owin.Authentication.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Owin.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Client.Configuration.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Client.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Collection.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Demo/code/Sitecore.Feature.Demo.csproj
+++ b/src/Feature/Demo/code/Sitecore.Feature.Demo.csproj
@@ -52,6 +52,9 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
@@ -59,112 +62,127 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Analytics.Model, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Model.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Analytics.XConnect, Version=11.15.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.XConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.CES.DeviceDetection, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.CES.DeviceDetection.dll</HintPath>
+    <Reference Include="Sitecore.CES.DeviceDetection, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.CES.DeviceDetection.NoReferences.9.0.171219\lib\NET462\Sitecore.CES.DeviceDetection.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Cintel, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Cintel.dll</HintPath>
+    <Reference Include="Sitecore.Cintel, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Cintel.NoReferences.9.0.171219\lib\NET462\Sitecore.Cintel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceAnalytics.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ExperienceAnalytics.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceAnalytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics.Api">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceAnalytics.Api.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics.Api, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ExperienceAnalytics.Api.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceAnalytics.Api.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ExperienceAnalytics.Core">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceAnalytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceAnalytics.Core, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ExperienceAnalytics.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceAnalytics.Core.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ExperienceEditor, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceEditor.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ExperienceExplorer.Core">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceExplorer.Core.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceExplorer.Core, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ExperienceExplorer.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceExplorer.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Framework.Conditions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Framework.Conditions.1.1.12\lib\net462\Sitecore.Framework.Conditions.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Marketing, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Marketing.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Marketing.Automation">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Marketing.Automation.dll</HintPath>
+    <Reference Include="Sitecore.Marketing, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.9.0.171219\lib\NET462\Sitecore.Marketing.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Marketing.Taxonomy, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Marketing.Taxonomy.dll</HintPath>
+    <Reference Include="Sitecore.Marketing.Automation, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Automation.NoReferences.9.0.171219\lib\NET462\Sitecore.Marketing.Automation.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Core, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Core.9.0.171219\lib\NET462\Sitecore.Marketing.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Taxonomy, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Taxonomy.9.0.171219\lib\NET462\Sitecore.Marketing.Taxonomy.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Mvc.Analytics">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Mvc.Analytics, Version=11.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Mvc.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.dll</HintPath>
+    <Reference Include="Sitecore.XConnect, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.9.0.171219\lib\NET462\Sitecore.XConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Client, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Client.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Client.Configuration, Version=0.14.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Client.Configuration.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Client.Configuration, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.Configuration.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Client.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Collection.Model, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Collection.Model.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Collection.Model, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Collection.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Collection.Model.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Diagnostics">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Diagnostics.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Diagnostics, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Diagnostics.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Search, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Search.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Search, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Search.9.0.171219\lib\NET462\Sitecore.XConnect.Search.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Segmentation.Conditions">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Segmentation.Conditions.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Segmentation.Conditions, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Conditions.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Conditions.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Segmentation.Engine">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Segmentation.Engine.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Segmentation.Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Engine.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Engine.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Segmentation.ExpressionBuilder.Model">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Segmentation.ExpressionBuilder.Model, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Segmentation.Predicates">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Segmentation.Predicates.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Segmentation.Predicates, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Predicates.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Predicates.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.XConnect.Segmentation.Predicates.Model">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Segmentation.Predicates.Model.dll</HintPath>
+    <Reference Include="Sitecore.XConnect.Segmentation.Predicates.Model, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Predicates.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Predicates.Model.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Xdb.MarketingAutomation.Tracking">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Xdb.MarketingAutomation.Tracking.dll</HintPath>
+    <Reference Include="Sitecore.Xdb.MarketingAutomation.Tracking, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Xdb.MarketingAutomation.Tracking.NoReferences.9.0.171219\lib\NET462\Sitecore.Xdb.MarketingAutomation.Tracking.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.Xdb.ReferenceData.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Xdb.ReferenceData.Core.9.0.171219\lib\NET462\Sitecore.Xdb.ReferenceData.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Interactive.Async, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Interactive.Async.3.1.1\lib\net46\System.Interactive.Async.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Interactive.Async.Providers, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Interactive.Async.Providers.3.1.1\lib\net45\System.Interactive.Async.Providers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\System.Reflection.4.1.0\lib\net462\System.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.4.1.0\lib\net462\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.Extensions.4.1.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.InteropServices.4.1.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/src/Feature/Demo/code/Web.config
+++ b/src/Feature/Demo/code/Web.config
@@ -47,6 +47,14 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Demo/code/packages.config
+++ b/src/Feature/Demo/code/packages.config
@@ -5,14 +5,58 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net462" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Remotion.Linq" version="2.1.1" targetFramework="net462" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.CES.DeviceDetection.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Cintel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.Api.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ExperienceAnalytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ExperienceExplorer.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Framework.Conditions" version="1.1.12" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Automation.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Core" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Taxonomy" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Mvc.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Client.Configuration.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Client.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Collection.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Diagnostics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Search" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Search.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Conditions.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Engine.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Predicates.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Predicates.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Xdb.MarketingAutomation.Tracking.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Xdb.ReferenceData.Core" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net462" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />
+  <package id="System.Interactive.Async" version="3.1.1" targetFramework="net462" />
+  <package id="System.Interactive.Async.Providers" version="3.1.1" targetFramework="net462" />
   <package id="System.Linq" version="4.1.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net462" />
+  <package id="System.Linq.Queryable" version="4.0.1" targetFramework="net462" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net462" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net462" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net462" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net462" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net462" />
 </packages>

--- a/src/Feature/Identity/code/Sitecore.Feature.Identity.csproj
+++ b/src/Feature/Identity/code/Sitecore.Feature.Identity.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Identity/code/Web.config
+++ b/src/Feature/Identity/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Identity/code/packages.config
+++ b/src/Feature/Identity/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Language/code/Sitecore.Feature.Language.csproj
+++ b/src/Feature/Language/code/Sitecore.Feature.Language.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Language/code/Web.config
+++ b/src/Feature/Language/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Language/code/packages.config
+++ b/src/Feature/Language/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Maps/code/Sitecore.Feature.Maps.csproj
+++ b/src/Feature/Maps/code/Sitecore.Feature.Maps.csproj
@@ -64,17 +64,15 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Speak.Client, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Speak.Client.dll</HintPath>
+    <Reference Include="Sitecore.Speak.Client, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Speak.Client.NoReferences.9.0.171219\lib\NET462\Sitecore.Speak.Client.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Feature/Maps/code/Web.config
+++ b/src/Feature/Maps/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Maps/code/packages.config
+++ b/src/Feature/Maps/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Media/code/Sitecore.Feature.Media.csproj
+++ b/src/Feature/Media/code/Sitecore.Feature.Media.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Media/code/Web.config
+++ b/src/Feature/Media/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Media/code/packages.config
+++ b/src/Feature/Media/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Metadata/code/Sitecore.Feature.Metadata.csproj
+++ b/src/Feature/Metadata/code/Sitecore.Feature.Metadata.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Metadata/code/Web.config
+++ b/src/Feature/Metadata/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Metadata/code/packages.config
+++ b/src/Feature/Metadata/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Multisite/code/Sitecore.Feature.Multisite.csproj
+++ b/src/Feature/Multisite/code/Sitecore.Feature.Multisite.csproj
@@ -59,9 +59,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Multisite/code/Web.config
+++ b/src/Feature/Multisite/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Multisite/code/packages.config
+++ b/src/Feature/Multisite/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Navigation/code/Sitecore.Feature.Navigation.csproj
+++ b/src/Feature/Navigation/code/Sitecore.Feature.Navigation.csproj
@@ -84,9 +84,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=11.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Navigation/code/Web.config
+++ b/src/Feature/Navigation/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Navigation/code/packages.config
+++ b/src/Feature/Navigation/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/News/code/Sitecore.Feature.News.csproj
+++ b/src/Feature/News/code/Sitecore.Feature.News.csproj
@@ -68,9 +68,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/News/code/Web.config
+++ b/src/Feature/News/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/News/code/packages.config
+++ b/src/Feature/News/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/PageContent/code/Sitecore.Feature.PageContent.csproj
+++ b/src/Feature/PageContent/code/Sitecore.Feature.PageContent.csproj
@@ -65,9 +65,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/PageContent/code/Web.config
+++ b/src/Feature/PageContent/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/PageContent/code/packages.config
+++ b/src/Feature/PageContent/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Person/code/Sitecore.Feature.Person.csproj
+++ b/src/Feature/Person/code/Sitecore.Feature.Person.csproj
@@ -67,9 +67,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=11.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Person/code/Web.config
+++ b/src/Feature/Person/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Person/code/packages.config
+++ b/src/Feature/Person/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Search/code/Sitecore.Feature.Search.csproj
+++ b/src/Feature/Search/code/Sitecore.Feature.Search.csproj
@@ -69,13 +69,11 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Buckets, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Buckets.dll</HintPath>
+    <Reference Include="Sitecore.Buckets, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Buckets.NoReferences.9.0.171219\lib\NET462\Sitecore.Buckets.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -85,9 +83,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Search/code/Web.config
+++ b/src/Feature/Search/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Search/code/packages.config
+++ b/src/Feature/Search/code/packages.config
@@ -10,6 +10,9 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net462" />
+  <package id="Sitecore.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Buckets.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />

--- a/src/Feature/Social/code/Sitecore.Feature.Social.csproj
+++ b/src/Feature/Social/code/Sitecore.Feature.Social.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Social/code/Web.config
+++ b/src/Feature/Social/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Social/code/packages.config
+++ b/src/Feature/Social/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/Teasers/code/Sitecore.Feature.Teasers.csproj
+++ b/src/Feature/Teasers/code/Sitecore.Feature.Teasers.csproj
@@ -68,9 +68,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=11.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/Teasers/code/Web.config
+++ b/src/Feature/Teasers/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/Teasers/code/packages.config
+++ b/src/Feature/Teasers/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Feature/faq/code/Sitecore.Feature.FAQ.csproj
+++ b/src/Feature/faq/code/Sitecore.Feature.FAQ.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Feature/faq/code/Web.config
+++ b/src/Feature/faq/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Feature/faq/code/packages.config
+++ b/src/Feature/faq/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/Accounts/code/Sitecore.Foundation.Accounts.csproj
+++ b/src/Foundation/Accounts/code/Sitecore.Foundation.Accounts.csproj
@@ -60,47 +60,100 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Analytics.Model, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Model.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Analytics.XConnect, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.XConnect.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.XConnect.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.XConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Framework.Conditions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Framework.Conditions.1.1.12\lib\net462\Sitecore.Framework.Conditions.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.9.0.171219\lib\NET462\Sitecore.Marketing.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Core, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Core.9.0.171219\lib\NET462\Sitecore.Marketing.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Taxonomy, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Taxonomy.9.0.171219\lib\NET462\Sitecore.Marketing.Taxonomy.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.9.0.171219\lib\NET462\Sitecore.XConnect.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Client.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Client.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect.Client.Configuration, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Client.Configuration.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.Configuration.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Client.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.XConnect.Collection.Model, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.XConnect.Collection.Model.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Collection.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Collection.Model.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.XConnect.Diagnostics, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Diagnostics.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.XConnect.Search, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Search.9.0.171219\lib\NET462\Sitecore.XConnect.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.XConnect.Segmentation.Conditions, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Conditions.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Conditions.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.XConnect.Segmentation.Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Engine.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.XConnect.Segmentation.ExpressionBuilder.Model, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.XConnect.Segmentation.Predicates, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Predicates.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Predicates.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.XConnect.Segmentation.Predicates.Model, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Segmentation.Predicates.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.XConnect.Segmentation.Predicates.Model.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Xdb.MarketingAutomation.Tracking, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Xdb.MarketingAutomation.Tracking.NoReferences.9.0.171219\lib\NET462\Sitecore.Xdb.MarketingAutomation.Tracking.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Xdb.ReferenceData.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Xdb.ReferenceData.Core.9.0.171219\lib\NET462\Sitecore.Xdb.ReferenceData.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Interactive.Async, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Interactive.Async.3.1.1\lib\net46\System.Interactive.Async.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Interactive.Async.Providers, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Interactive.Async.Providers.3.1.1\lib\net45\System.Interactive.Async.Providers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\System.Reflection.4.1.0\lib\net462\System.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.4.1.0\lib\net462\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.Extensions.4.1.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.InteropServices.4.1.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/src/Foundation/Accounts/code/Web.config
+++ b/src/Foundation/Accounts/code/Web.config
@@ -47,6 +47,14 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Accounts/code/packages.config
+++ b/src/Foundation/Accounts/code/packages.config
@@ -4,13 +4,50 @@
   <package id="MicroCHAP" version="1.2.2.2" targetFramework="net462" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Remotion.Linq" version="2.1.1" targetFramework="net462" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.XConnect.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Framework.Conditions" version="1.1.12" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Core" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Taxonomy" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Client.Configuration.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Client.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Collection.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Diagnostics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Search" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Search.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Conditions.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Engine.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.ExpressionBuilder.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Predicates.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.XConnect.Segmentation.Predicates.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Xdb.MarketingAutomation.Tracking.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Xdb.ReferenceData.Core" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net462" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />
+  <package id="System.Interactive.Async" version="3.1.1" targetFramework="net462" />
+  <package id="System.Interactive.Async.Providers" version="3.1.1" targetFramework="net462" />
   <package id="System.Linq" version="4.1.0" targetFramework="net462" />
   <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net462" />
+  <package id="System.Linq.Queryable" version="4.0.1" targetFramework="net462" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net462" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net462" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net462" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net462" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net462" />
 </packages>

--- a/src/Foundation/Alerts/code/Sitecore.Foundation.Alerts.csproj
+++ b/src/Foundation/Alerts/code/Sitecore.Foundation.Alerts.csproj
@@ -60,9 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Foundation/Alerts/code/Web.config
+++ b/src/Foundation/Alerts/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Alerts/code/packages.config
+++ b/src/Foundation/Alerts/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/Assets/code/Sitecore.Foundation.Assets.csproj
+++ b/src/Foundation/Assets/code/Sitecore.Foundation.Assets.csproj
@@ -63,13 +63,11 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.dll</HintPath>
+    <Reference Include="Sitecore.Mvc, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.NoReferences.9.0.171219\lib\NET462\Sitecore.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Foundation/Assets/code/packages.config
+++ b/src/Foundation/Assets/code/packages.config
@@ -8,6 +8,8 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Mvc.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/Assets/code/web.config
+++ b/src/Foundation/Assets/code/web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/DependencyInjection/code/Sitecore.Foundation.DependencyInjection.csproj
+++ b/src/Foundation/DependencyInjection/code/Sitecore.Foundation.DependencyInjection.csproj
@@ -60,8 +60,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/Foundation/DependencyInjection/code/packages.config
+++ b/src/Foundation/DependencyInjection/code/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />

--- a/src/Foundation/Dictionary/code/Sitecore.Foundation.Dictionary.csproj
+++ b/src/Foundation/Dictionary/code/Sitecore.Foundation.Dictionary.csproj
@@ -61,13 +61,11 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.dll</HintPath>
+    <Reference Include="Sitecore.Mvc, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.NoReferences.9.0.171219\lib\NET462\Sitecore.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Foundation/Dictionary/code/Web.config
+++ b/src/Foundation/Dictionary/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Dictionary/code/packages.config
+++ b/src/Foundation/Dictionary/code/packages.config
@@ -8,6 +8,8 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Mvc.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/FieldEditor/code/Sitecore.Foundation.FieldEditor.csproj
+++ b/src/Foundation/FieldEditor/code/Sitecore.Foundation.FieldEditor.csproj
@@ -65,9 +65,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceEditor.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Foundation/FieldEditor/code/Web.config
+++ b/src/Foundation/FieldEditor/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/FieldEditor/code/packages.config
+++ b/src/Foundation/FieldEditor/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/Indexing/code/Sitecore.Foundation.Indexing.csproj
+++ b/src/Foundation/Indexing/code/Sitecore.Foundation.Indexing.csproj
@@ -68,9 +68,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Abstractions, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Abstractions.dll</HintPath>
+    <Reference Include="Sitecore.Abstractions, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Abstractions.NoReferences.9.0.171219\lib\NET462\Sitecore.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -80,9 +79,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Foundation/Indexing/code/packages.config
+++ b/src/Foundation/Indexing/code/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />

--- a/src/Foundation/Indexing/code/web.config
+++ b/src/Foundation/Indexing/code/web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Installer/code/Sitecore.Foundation.Installer.csproj
+++ b/src/Foundation/Installer/code/Sitecore.Foundation.Installer.csproj
@@ -61,8 +61,8 @@
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Foundation/Installer/code/packages.config
+++ b/src/Foundation/Installer/code/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-    <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />
-    <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net462" />
-    <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net462" />
-    <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
-    <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
-    <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net462" />
-    <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net462" />
-    <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net462" />
-    <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
-    <package id="Microsoft.SqlServer.Scripting" version="11.0.2100.61" targetFramework="net462" />
-    <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
-    <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net462" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net462" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net462" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.SqlServer.Scripting" version="11.0.2100.61" targetFramework="net462" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/src/Foundation/LocalDatasource/code/Sitecore.Foundation.LocalDatasource.csproj
+++ b/src/Foundation/LocalDatasource/code/Sitecore.Foundation.LocalDatasource.csproj
@@ -59,17 +59,15 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Buckets, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Buckets.dll</HintPath>
+    <Reference Include="Sitecore.Buckets, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Buckets.NoReferences.9.0.171219\lib\NET462\Sitecore.Buckets.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ContentSearch, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Foundation/LocalDatasource/code/packages.config
+++ b/src/Foundation/LocalDatasource/code/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/LocalDatasource/code/web.config
+++ b/src/Foundation/LocalDatasource/code/web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Multisite/code/Sitecore.Foundation.Multisite.csproj
+++ b/src/Foundation/Multisite/code/Sitecore.Foundation.Multisite.csproj
@@ -69,9 +69,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceEditor.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/Foundation/Multisite/code/Web.config
+++ b/src/Foundation/Multisite/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Multisite/code/packages.config
+++ b/src/Foundation/Multisite/code/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />

--- a/src/Foundation/Serialization/code/Sitecore.Foundation.Serialization.csproj
+++ b/src/Foundation/Serialization/code/Sitecore.Foundation.Serialization.csproj
@@ -79,9 +79,8 @@
     <Reference Include="Rainbow.Storage.Yaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Rainbow.Storage.Yaml.2.0.0\lib\net452\Rainbow.Storage.Yaml.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Foundation/Serialization/code/packages.config
+++ b/src/Foundation/Serialization/code/packages.config
@@ -15,6 +15,7 @@
   <package id="Rainbow.Core" version="2.0.0" targetFramework="net462" />
   <package id="Rainbow.Storage.Sc" version="2.0.0" targetFramework="net462" />
   <package id="Rainbow.Storage.Yaml" version="2.0.0" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/SitecoreExtensions/code/Sitecore.Foundation.SitecoreExtensions.csproj
+++ b/src/Foundation/SitecoreExtensions/code/Sitecore.Foundation.SitecoreExtensions.csproj
@@ -59,6 +59,9 @@
       <HintPath>..\..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
@@ -66,43 +69,54 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Model.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ContentSearch.NoReferences.9.0.171219\lib\NET462\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch.Linq, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch.Linq, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ContentSearch.Linq.NoReferences.9.0.171219\lib\NET462\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ExperienceEditor, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ExperienceEditor.dll</HintPath>
+    <Reference Include="Sitecore.ExperienceEditor, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.ExperienceEditor.NoReferences.9.0.171219\lib\NET462\Sitecore.ExperienceEditor.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Framework.Conditions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Framework.Conditions.1.1.12\lib\net462\Sitecore.Framework.Conditions.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Marketing">
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Marketing.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.dll</HintPath>
+    <Reference Include="Sitecore.Marketing, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.9.0.171219\lib\NET462\Sitecore.Marketing.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Core, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Core.9.0.171219\lib\NET462\Sitecore.Marketing.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Search, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Search.NoReferences.9.0.171219\lib\NET462\Sitecore.Marketing.Search.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Marketing.Taxonomy, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Marketing.Taxonomy.9.0.171219\lib\NET462\Sitecore.Marketing.Taxonomy.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Mvc, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.NoReferences.9.0.171219\lib\NET462\Sitecore.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.4.1.0\lib\net462\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.InteropServices.4.1.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/Foundation/SitecoreExtensions/code/packages.config
+++ b/src/Foundation/SitecoreExtensions/code/packages.config
@@ -6,9 +6,22 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ContentSearch.Linq.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ContentSearch.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.ExperienceEditor.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Framework.Conditions" version="1.1.12" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Core" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Taxonomy" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Mvc.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
@@ -18,7 +31,9 @@
   <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net462" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net462" requireReinstallation="true" />
   <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net462" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net462" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net462" requireReinstallation="true" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net462" />
   <package id="System.Threading" version="4.0.11" targetFramework="net462" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net462" />
 </packages>

--- a/src/Foundation/SitecoreExtensions/code/web.config
+++ b/src/Foundation/SitecoreExtensions/code/web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Theming/code/Sitecore.Foundation.Theming.csproj
+++ b/src/Foundation/Theming/code/Sitecore.Foundation.Theming.csproj
@@ -188,9 +188,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=11.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Foundation/Theming/code/Web.config
+++ b/src/Foundation/Theming/code/Web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Foundation/Theming/code/packages.config
+++ b/src/Foundation/Theming/code/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Project/Common/code/Sitecore.Common.Website.csproj
+++ b/src/Project/Common/code/Sitecore.Common.Website.csproj
@@ -65,9 +65,8 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Project/Common/code/packages.config
+++ b/src/Project/Common/code/packages.config
@@ -14,6 +14,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Project/Common/code/web.config
+++ b/src/Project/Common/code/web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>

--- a/src/Project/Habitat/code/Sitecore.Habitat.Website.csproj
+++ b/src/Project/Habitat/code/Sitecore.Habitat.Website.csproj
@@ -68,33 +68,28 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Analytics, Version=11.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Core, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Core.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Core, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Core.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Analytics.Model, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Analytics.Model.dll</HintPath>
+    <Reference Include="Sitecore.Analytics.Model, Version=11.40.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Analytics.Model.NoReferences.9.0.171219\lib\NET462\Sitecore.Analytics.Model.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=11.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Kernel.NoReferences.9.0.171219\lib\NET462\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Mvc.Analytics, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\lib\Sitecore\Sitecore.Mvc.Analytics.dll</HintPath>
+    <Reference Include="Sitecore.Mvc.Analytics, Version=11.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.Analytics.NoReferences.9.0.171219\lib\NET462\Sitecore.Mvc.Analytics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Project/Habitat/code/packages.config
+++ b/src/Project/Habitat/code/packages.config
@@ -13,6 +13,10 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="Sitecore.Analytics.Core.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.Model.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Analytics.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Project/Habitat/code/web.config
+++ b/src/Project/Habitat/code/web.config
@@ -47,6 +47,10 @@
                 <assemblyIdentity name="System.Interactive.Async" culture="neutral" publicKeyToken="94bc3704cddfc263" />
                 <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <system.codedom>


### PR DESCRIPTION
The feature/v9 branch was using references to Sitecore (and other) DLLs in the lib folder.  This PR adds Nuget references instead.  It's worth noting that the feature/v9 branch had many build errors.  These Nuget references fix them.