### PR TITLE
fixes for fetching the url of link item in media carousel

### DIFF
--- a/src/Feature/Media/code/Views/MediaFeature/MediaCarousel.cshtml
+++ b/src/Feature/Media/code/Views/MediaFeature/MediaCarousel.cshtml
@@ -52,7 +52,7 @@
           @if (element.Item.IsDerived(Templates.HasMediaVideo.ID))
           {
             <video autoplay="" loop="" muted="" class="video-bg img-responsive">
-              <source src="@element.Item.MediaUrl(Templates.HasMediaVideo.Fields.VideoLink)" type="video/mp4">
+              <source src="@element.Item.LinkFieldUrl(Templates.HasMediaVideo.Fields.VideoLink)" type="video/mp4">
             </video>
           }
 

--- a/src/Feature/Media/code/Views/MediaFeature/PageHeaderCarousel.cshtml
+++ b/src/Feature/Media/code/Views/MediaFeature/PageHeaderCarousel.cshtml
@@ -38,7 +38,7 @@
           @if (element.Item.IsDerived(Templates.HasMediaVideo.ID))
           {
             <video autoplay="" loop="" muted="" class="video-bg">
-              <source src="@element.Item.MediaUrl(Templates.HasMediaVideo.Fields.VideoLink)" type="video/mp4">
+              <source src="@element.Item.LinkFieldUrl(Templates.HasMediaVideo.Fields.VideoLink)" type="video/mp4">
             </video>
           }
 


### PR DESCRIPTION
the MediaCarousel and PageHeaderMediaCarousel both we're unable to fetch the video url of a external video item if referenced in the carousel.
the frontend still needs some work to render a video in the carousel but at least the video url is being fetched from the media item rather than 'string.empty'