### PR TITLE
Added missing dependencies in the packages.config for two modules.

### DIFF
--- a/src/Feature/Maps/code/packages.config
+++ b/src/Feature/Maps/code/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Speak.Client.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />

--- a/src/Foundation/SitecoreExtensions/code/packages.config
+++ b/src/Foundation/SitecoreExtensions/code/packages.config
@@ -20,6 +20,7 @@
   <package id="Sitecore.Kernel.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.Marketing" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.Marketing.Core" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
+  <package id="Sitecore.Marketing.Search.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.Marketing.Taxonomy" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="Sitecore.Mvc.NoReferences" version="9.0.171219" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />


### PR DESCRIPTION
There are issues doing a Nuget-Restore from the gulp command line because two modules have references to assemblies that aren't included in the nuget package references. This adds the two references that are missing and makes command line gulp processes work as expected without opening the IDE to fix them.

Questions/Concerns: dco@sitecore.net