### PR TITLE
Feature/901docs and #390 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sitecore Habitat
 
-Habitat is an example Sitecore solution built on the [Helix architecture principles](http://helix.sitecore.net).  It is designed to show how a Helix-based solution can be architected, and to demonstrate how tooling can be used to accomplish publishing, serialization, and testing. Habitat **is not intended** to be a starter solution, or as a reccomendation of tools for your solutions.
+Habitat is an example Sitecore solution built on the [Helix architecture principles](http://helix.sitecore.net).  It is designed to show how a Helix-based solution can be architected, and to demonstrate how tooling can be used to accomplish publishing, serialization, and testing. Habitat **is not intended** to be a starter solution, or as a recommendation of tools for your solutions.
 
 The architecture and methodology focuses on:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sitecore Habitat
 
-Habitat and the tools and processes in it is a Sitecore solution example built on the [Helix architecture principles](http://helix.sitecore.net).  
+Habitat is an example Sitecore solution built on the [Helix architecture principles](http://helix.sitecore.net).  It is designed to show how a Helix-based solution can be architected, and to demonstrate how tooling can be used to accomplish publishing, serialization, and testing. Habitat **is not intended** to be a starter solution, or as a requirement on tooling in your solutions.
+
 The architecture and methodology focuses on:
 
 * Simplicity - *A consistent and discoverable architecture*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sitecore Habitat
 
-Habitat is an example Sitecore solution built on the [Helix architecture principles](http://helix.sitecore.net).  It is designed to show how a Helix-based solution can be architected, and to demonstrate how tooling can be used to accomplish publishing, serialization, and testing. Habitat **is not intended** to be a starter solution, or as a requirement on tooling in your solutions.
+Habitat is an example Sitecore solution built on the [Helix architecture principles](http://helix.sitecore.net).  It is designed to show how a Helix-based solution can be architected, and to demonstrate how tooling can be used to accomplish publishing, serialization, and testing. Habitat **is not intended** to be a starter solution, or as a reccomendation of tools for your solutions.
 
 The architecture and methodology focuses on:
 

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -18,10 +18,10 @@ This project assumes the following settings:
 
 <sup>1</sup> Files referred are:
 
-* `./src/Project/Habitat/code/App_Config/Environment/Project/Habitat.Dev.config`
-* `./gulp-config.js`
-* `./publishsettings.targets`
-* `./settings.ps1`
+* `.\src\Project\Habitat\code\App_Config\Environment\Project\Habitat.Dev.config`
+* `.\gulp-config.js`
+* `.\publishsettings.targets`
+* `.\settings.ps1`
 * `.\build\assets\sitecore-XP0.json`
 * `.\build\assets\xconnect-XP0.json`
 
@@ -38,7 +38,7 @@ The Sitecore install script will check some prerequisites.
 ### Solr
 
 The installation requires the Apache Solr search engine.
-Solr must be running as a windows service, e.g. through running [NSSM](https://sitecore.stackexchange.com/questions/1211/how-to-get-solr-to-run-as-a-service)
+Solr must be running as a windows service. This can be accomplished through running [NSSM](https://sitecore.stackexchange.com/questions/1211/how-to-get-solr-to-run-as-a-service)
 Furthermore, Sitecore is secure by default and therefore Solr must be running as https.
 To create an SSL certificate for Solr follow the following steps (make sure your Solr settings are correctly configured in `settings.ps1`):
 

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -30,7 +30,7 @@ This project assumes the following settings:
 **Important!: Check the prerequisites before starting the installation.**
 
 * **Do check** the prerequisites of Sitecore Experience Platform in the release notes available on [dev.sitecore.net](dev.sitecore.net)
-* **Do check** the [[Resources|02 Resources]] page for the tools needed
+* **Do check** the [Resources](./02-Resources.md) page for the tools needed
 * **Always** run your Visual Studio or PowerShell Command Line with elevated privileges or *As Administrator*
 
 The Sitecore install script will check some prerequisites.

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -29,7 +29,7 @@ This project assumes the following settings:
 
 **Important!: Check the prerequisites before starting the installation.**
 
-* **Do check** the prerequisites of Sitecore Experience Platform in the release notes available on [dev.sitecore.net](dev.sitecore.net)
+* **Do check** the prerequisites of Sitecore Experience Platform in the release notes available on [dev.sitecore.net](https://dev.sitecore.net)
 * **Do check** the [Resources](./02-Resources.md) page for the tools needed
 * **Always** run your Visual Studio or PowerShell Command Line with elevated privileges or *As Administrator*
 

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -48,7 +48,7 @@ The Sitecore install script will check some prerequisites.
 ### Solr
 
 The installation requires the Apache Solr search engine.
-Solr must be running as a windows service. This can be accomplished through running [NSSM](https://sitecore.stackexchange.com/questions/1211/how-to-get-solr-to-run-as-a-service)
+Solr must be running as a windows service. This can be accomplished through running [NSSM](https://sitecore.stackexchange.com/questions/1211/how-to-get-solr-to-run-as-a-service). 
 Furthermore, Sitecore is secure by default and therefore Solr must be running as https.
 To create an SSL certificate for Solr follow the following steps (make sure your Solr settings are correctly configured in `settings.ps1`):
 

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -1,5 +1,15 @@
 # Getting Started
 
+## Software Versions
+
+This version of Habitat uses the following versions of this software:
+
+| Software      | Version |
+| ---           | --- |
+| Sitecore      | 9.0 Update 1, rev 171219 |
+| Solr          | 6.6.2 |
+| Sitecore Installation Framework | 1.2.1 |
+
 ## Locations and settings
 
 This project assumes the following settings:

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -49,8 +49,8 @@ The Sitecore install script will check some prerequisites.
 
 The installation requires the Apache Solr search engine.
 Solr must be running as a windows service. This can be accomplished through running [NSSM](https://sitecore.stackexchange.com/questions/1211/how-to-get-solr-to-run-as-a-service). 
-Furthermore, Sitecore is secure by default and therefore Solr must be running as https.
-To create an SSL certificate for Solr follow the following steps (make sure your Solr settings are correctly configured in `settings.ps1`):
+Furthermore, Sitecore is secure by default and therefore Solr must be running as https. 
+If your Solr environment is not currently running with HTTPS, you can create an SSL certificate for Solr by following these steps (make sure your Solr settings are correctly configured in `settings.ps1`):
 
 1. Open an elevated PowerShell command line.
 1. Run `.\build\GenerateSolrCertificate.ps1` to generate the certificate file in the correct location.

--- a/docs/02-Resources.md
+++ b/docs/02-Resources.md
@@ -41,5 +41,5 @@ A separate fork of the Habitat project with support for [Team Development for Si
 ### ORM
 
 If you are interested in using an ORM tool like Glass or Synthesis with Habitat, please refer to these examples:
-https://github.com/kamsar/Habitat/tree/HabitatSynthesis
-https://github.com/muso31/Habitat-Glass.Mapper
+* https://github.com/kamsar/Habitat/tree/HabitatSynthesis
+* https://github.com/muso31/Habitat-Glass.Mapper

--- a/docs/02-Resources.md
+++ b/docs/02-Resources.md
@@ -28,11 +28,11 @@ These are additional tools used in Habitat's creation. You do not need to instal
 * Specification Testing: SpecFlow
 * Environment: [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784) (required only for Foundation.Installer module)
 
-Sitecore does not endorse any particular third-party tool. The tools in the current release were chosen because of a number of reasons including popularity and ease of licensing. This does not preclude using other tools in Habitat or changing any third-party tool for another depending on feedback from the Sitecore community.
+Sitecore does not endorse any particular third-party tool. The tools in the current release were chosen because of a number of reasons, including popularity and ease of licensing. Habitat is an example to show you how you can use these tools to accomplish a feature complete and functional solution. This does not preclude using other tools in your Helix solutions, or changing any third-party tool for another depending on feedback from the Sitecore community.
 
 The project uses the Bootstrap theme implemented in [Sitecore.Demo.Theme](https://github.com/Sitecore/Sitecore.Demo.Theme)
 
-## Alternates
+## Habitat forks using other tools
 
 ### Team Development for Sitecore
 

--- a/docs/03-Licensing.md
+++ b/docs/03-Licensing.md
@@ -1,4 +1,4 @@
-Copyright 2017 Sitecore Corporation A/S
+Copyright 2017-2018 Sitecore Corporation A/S
 
 Licensed under the Apache License, Version 2.0 (the "License"); You may not use this solution except in compliance with the License.
 

--- a/docs/04-Contribute.md
+++ b/docs/04-Contribute.md
@@ -2,6 +2,7 @@
 
 A huge thanks to people who have contributed to the project in different ways:
 
+* [Thomas Eldblom](https://community.sitecore.net/members/thomaseldblom_5f00_1660698798)
 * [Anders Laub Christoffersen](https://community.sitecore.net/members/anderschristoffersen_5f00_688677062)
 * [Kam Figy](https://community.sitecore.net/members/kamfigy_5f00_1576112879)
 * [Göran Halvarsson](https://community.sitecore.net/members/goranhalvarsson_5f00_1482267179)
@@ -17,6 +18,11 @@ A huge thanks to people who have contributed to the project in different ways:
 * [Martina Welander](https://community.sitecore.net/members/martinawelander_5f00_196869926)
 * [Nick Wesselman](https://community.sitecore.net/members/nickwesselman_5f00_1267813303)
 * [Dan Zhang](https://community.sitecore.net/members/danzhang_5f00_293572842)
+* [Berend Haan](https://community.sitecore.net/members/berendhaan_5f00_2052239761)
+* [Jean-Francois Larente](https://community.sitecore.net/members/jflsitecorenet_5f00_5702343)
+* Sergey Kravchenko
+* [Derek Correia](https://community.sitecore.net/members/derekcorreia_5f00_471126827)
+* [James Skemp](https://community.sitecore.net/members/jamesskemp_5f00_913063860)
 * ...and of course the internal Habitat team @ Sitecore
 
 *Any omissions are completely unintentional.*

--- a/docs/04-Contribute.md
+++ b/docs/04-Contribute.md
@@ -20,9 +20,10 @@ A huge thanks to people who have contributed to the project in different ways:
 * [Dan Zhang](https://community.sitecore.net/members/danzhang_5f00_293572842)
 * [Berend Haan](https://community.sitecore.net/members/berendhaan_5f00_2052239761)
 * [Jean-Francois Larente](https://community.sitecore.net/members/jflsitecorenet_5f00_5702343)
-* Sergey Kravchenko
 * [Derek Correia](https://community.sitecore.net/members/derekcorreia_5f00_471126827)
 * [James Skemp](https://community.sitecore.net/members/jamesskemp_5f00_913063860)
+* Sergey Kravchenko
+* James Hirka
 * ...and of course the internal Habitat team @ Sitecore
 
 *Any omissions are completely unintentional.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,15 @@
-## What is the goal of this project?
+# Sitecore Habitat
 
-Habitat is a Sitecore solution example built on a modular architecture. The architecture and methodology focuses on:
+Habitat is an example Sitecore solution built on the [Helix architecture principles](http://helix.sitecore.net).  It is designed to show how a Helix-based solution can be architected, and to demonstrate how tooling can be used to accomplish publishing, serialization, and testing. Habitat **is not intended** to be a starter solution, or as a recommendation of tools for your solutions.
+
+The architecture and methodology focuses on:
 
 * Simplicity - *A consistent and discoverable architecture*
 * Flexibility - *Change and add quickly and without worry*
 * Extensibility - *Simply add new features without steep learning curve*
+
+For getting started, please check out the [Documentation](./docs).  
+For more information on **Helix**, please go to [helix.sitecore.net](http://helix.sitecore.net).
 
 For more information about the architecture and the principles and conventions behind it, please see the [Sitecore Helix guidelines](http://helix.sitecore.net)
 
@@ -13,5 +18,3 @@ Video introductions:
 1. Architecture Introduction: [Video](https://youtu.be/2CELqflPhm0)  
 2. Introduction to Modules: [Video](https://youtu.be/DgPrikqFe4s)  
 3. Introduction to Layers: [Video](https://youtu.be/XKLpTMuQT4Y)
-
-**To get started on Habitat, read the [[Getting Started|01 Getting Started]] section**

--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -83,14 +83,6 @@ function Install-Prerequisites {
         throw "Could load the Microsoft.SqlServer.TransactSql.ScriptDom assembly. Please make sure it is installed and registered in the GAC"
     }
     
-    #Add ApplicationPoolIdentity to performance log users to avoid Sitecore log errors (https://kb.sitecore.net/articles/404548)
-    if (!(Get-LocalGroupMember "Performance Log Users" "IIS AppPool\DefaultAppPool")) {
-        Add-LocalGroupMember "Performance Log Users" "IIS AppPool\DefaultAppPool"    
-    }
-    if (!(Get-LocalGroupMember "Performance Monitor Users" "IIS AppPool\DefaultAppPool")) {
-        Add-LocalGroupMember "Performance Monitor Users" "IIS AppPool\DefaultAppPool"
-    }
-    
     #Enable Contained Databases
     Write-Host "Enable contained databases" -ForegroundColor Green
     try
@@ -307,10 +299,36 @@ function Install-Sitecore {
     }
 }
 
+function Add-AppPool-Membership {
+
+    #Add ApplicationPoolIdentity to performance log users to avoid Sitecore log errors (https://kb.sitecore.net/articles/404548)
+    
+    try 
+    {
+        Add-LocalGroupMember "Performance Log Users" "IIS AppPool\$SitecoreSiteName"
+        Write-Host "Added IIS AppPool\$SitecoreSiteName to Performance Log Users" -ForegroundColor Green
+    }
+    catch 
+    {
+        Write-Host "Warning: Couldn't add IIS AppPool\$SitecoreSiteName to Performance Log Users -- user may already exist" -ForegroundColor Yellow
+    }
+    try 
+    {
+        Add-LocalGroupMember "Performance Monitor Users" "IIS AppPool\$SitecoreSiteName"
+        Write-Host "Added IIS AppPool\$SitecoreSiteName to Performance Monitor Users" -ForegroundColor Green
+    }
+    catch 
+    {
+        Write-Host "Warning: Couldn't add IIS AppPool\$SitecoreSiteName to Performance Monitor Users -- user may already exist" -ForegroundColor Yellow
+    }
+}
+
 Install-Prerequisites
 Install-Assets
 Install-XConnect
 Install-Sitecore
+Add-AppPool-Membership
+
 
 # TODO: 
 # Run optimization scripts

--- a/settings.ps1
+++ b/settings.ps1
@@ -2,10 +2,7 @@
 $SolutionPrefix = "habitat"
 $SitePostFix = "dev.local"
 $webroot = "C:\inetpub\wwwroot"
-$webroot = "C:\Inetpub\wwwroot"
 
-$SitecoreVersion = "9.0.0 rev. 171002"
-$InstallerVersion = "1.0.2"
 $SitecoreVersion = "9.0.1 rev. 171219"
 $InstallerVersion = "1.2.1"
 

--- a/uninstall-xp0.ps1
+++ b/uninstall-xp0.ps1
@@ -88,3 +88,23 @@ Start-Service $SolrService
 
 # Delete sitecore certificate
 Remove-SitecoreCertificate $SitecoreSiteName
+
+# Remove App Pool membership 
+try 
+{
+    Remove-LocalGroupMember "Performance Log Users" "IIS AppPool\$SitecoreSiteName"
+    Write-Host "Removed IIS AppPool\$SitecoreSiteName from Performance Log Users" -ForegroundColor Green
+}
+catch 
+{
+    Write-Host "Could not find IIS AppPool\$SitecoreSiteName in Performance Log Users" -ForegroundColor Yellow
+}
+try 
+{
+    Remove-LocalGroupMember "Performance Monitor Users" "IIS AppPool\$SitecoreSiteName"
+    Write-Host "Removed IIS AppPool\$SitecoreSiteName from Performance Monitor Users" -ForegroundColor Green
+}
+catch 
+{
+    Write-Host "Could not find IIS AppPool\$SitecoreSiteName to Performance Monitor Users" -ForegroundColor Yellow
+}


### PR DESCRIPTION
First pass on docs for 9.0.1:
* Added Version list to top of 01
* Minor fixes for broken links
* Added clarifying language around Habitat being an example, not requirements or a starter kit
* Added Contributors since last update

Fix for #390 
* Moved membership for the app pool to after the installation, in case a prior error out
* Uses $SitecoreSiteName
* Moved to try-catch format due to errors stemming from the if check
* Removes membership in Uninstall script

Removed redundant variable definitions from Settings.ps1