### PR TITLE
Adding '-Repository $AssetPSRepositoryName' to install.ps1

### DIFF
--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -148,7 +148,7 @@ function Install-Assets {
     $module = Get-Module -FullyQualifiedName @{ModuleName="SitecoreInstallFramework";ModuleVersion=$InstallerVersion}
     if (-not $module) {
         write-host "Installing the Sitecore Install Framework, version $InstallerVersion" -ForegroundColor Green
-        Install-Module SitecoreInstallFramework -RequiredVersion $InstallerVersion -Scope CurrentUser
+        Install-Module SitecoreInstallFramework -RequiredVersion $InstallerVersion -Scope CurrentUser -Repository $AssetsPSRepositoryName
         Import-Module SitecoreInstallFramework -RequiredVersion $InstallerVersion
     }
 


### PR DESCRIPTION
Adding '-Repository $AssetPSRepositoryName' to the SitecoreInstallFramework installation call to ensure a specific repository is used.

Issue would only come up with Sitecore employees who have access to multiple repositories that host SitecoreInstallFramework but it's not a bad idea to have the Repository specified since it's already captured in the settings.ps1 file.