### PR TITLE
Feature/strong sql passwords

### DIFF
--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -218,10 +218,10 @@ function Install-XConnect {
                                       -SqlCollectionUser $XConnectSqlCollectionUser `
                                       -SqlCollectionPassword $XConnectSqlCollectionPassword `
                                       -SolrUrl $SolrUrl `
-                                      -SqlProcessingPoolsPassword $SQLStrongPassword `
-                                      -SqlReferenceDataPassword $SQLStrongPassword `
-                                      -SqlMarketingAutomationPassword $SQLStrongPassword `
-                                      -SqlMessagingPassword $SQLStrongPassword `
+                                      -SqlProcessingPoolsPassword $SqlStrongPassword `
+                                      -SqlReferenceDataPassword $SqlStrongPassword `
+                                      -SqlMarketingAutomationPassword $SqlStrongPassword `
+                                      -SqlMessagingPassword $SqlStrongPassword `
 
     }
     catch
@@ -284,17 +284,17 @@ function Install-Sitecore {
                                       -XConnectReferenceDataService "https://$XConnectSiteName" `
                                       -MarketingAutomationOperationsService "https://$XConnectSiteName" `
                                       -MarketingAutomationReportingService "https://$XConnectSiteName" `
-                                      -SqlCorePassword $SQLStrongPassword `
-                                      -SqlMasterPassword $SQLStrongPassword `
-                                      -SqlWebPassword $SQLStrongPassword `
-                                      -SqlReportingPassword $SQLStrongPassword `
-                                      -SqlProcessingPoolsPassword $SQLStrongPassword `
-                                      -SqlProcessingTasksPassword $SQLStrongPassword `
-                                      -SqlReferenceDataPassword $SQLStrongPassword `
-                                      -SqlMarketingAutomationPassword $SQLStrongPassword `
-                                      -SqlFormsPassword $SQLStrongPassword `
-                                      -SqlExmMasterPassword $SQLStrongPassword `
-                                      -SqlMessagingPassword $SQLStrongPassword `
+                                      -SqlCorePassword $SqlStrongPassword `
+                                      -SqlMasterPassword $SqlStrongPassword `
+                                      -SqlWebPassword $SqlStrongPassword `
+                                      -SqlReportingPassword $SqlStrongPassword `
+                                      -SqlProcessingPoolsPassword $SqlStrongPassword `
+                                      -SqlProcessingTasksPassword $SqlStrongPassword `
+                                      -SqlReferenceDataPassword $SqlStrongPassword `
+                                      -SqlMarketingAutomationPassword $SqlStrongPassword `
+                                      -SqlFormsPassword $SqlStrongPassword `
+                                      -SqlExmMasterPassword $SqlStrongPassword `
+                                      -SqlMessagingPassword $SqlStrongPassword `
 
     }
     catch

--- a/install-xp0.ps1
+++ b/install-xp0.ps1
@@ -217,7 +217,12 @@ function Install-XConnect {
                                       -SqlServer $SqlServer `
                                       -SqlCollectionUser $XConnectSqlCollectionUser `
                                       -SqlCollectionPassword $XConnectSqlCollectionPassword `
-                                      -SolrUrl $SolrUrl
+                                      -SolrUrl $SolrUrl `
+                                      -SqlProcessingPoolsPassword $SQLStrongPassword `
+                                      -SqlReferenceDataPassword $SQLStrongPassword `
+                                      -SqlMarketingAutomationPassword $SQLStrongPassword `
+                                      -SqlMessagingPassword $SQLStrongPassword `
+
     }
     catch
     {
@@ -278,7 +283,19 @@ function Install-Sitecore {
                                       -XConnectCollectionService "https://$XConnectSiteName" `
                                       -XConnectReferenceDataService "https://$XConnectSiteName" `
                                       -MarketingAutomationOperationsService "https://$XConnectSiteName" `
-                                      -MarketingAutomationReportingService "https://$XConnectSiteName"
+                                      -MarketingAutomationReportingService "https://$XConnectSiteName" `
+                                      -SqlCorePassword $SQLStrongPassword `
+                                      -SqlMasterPassword $SQLStrongPassword `
+                                      -SqlWebPassword $SQLStrongPassword `
+                                      -SqlReportingPassword $SQLStrongPassword `
+                                      -SqlProcessingPoolsPassword $SQLStrongPassword `
+                                      -SqlProcessingTasksPassword $SQLStrongPassword `
+                                      -SqlReferenceDataPassword $SQLStrongPassword `
+                                      -SqlMarketingAutomationPassword $SQLStrongPassword `
+                                      -SqlFormsPassword $SQLStrongPassword `
+                                      -SqlExmMasterPassword $SQLStrongPassword `
+                                      -SqlMessagingPassword $SQLStrongPassword `
+
     }
     catch
     {

--- a/settings.ps1
+++ b/settings.ps1
@@ -20,7 +20,7 @@ $CertPath = Join-Path "$AssetsRoot" "Certificates"
 $SqlServer = "."
 $SqlAdminUser = "sa"
 $SqlAdminPassword = "12345"
-$SQLStrongPassword = "Str0NgPA33w0rd!!" # Used for all other services
+$SqlStrongPassword = "Str0NgPA33w0rd!!" # Used for all other services
 
 # XConnect Parameters
 $XConnectConfiguration = "$AssetsRoot\xconnect-xp0.json"

--- a/settings.ps1
+++ b/settings.ps1
@@ -20,6 +20,7 @@ $CertPath = Join-Path "$AssetsRoot" "Certificates"
 $SqlServer = "."
 $SqlAdminUser = "sa"
 $SqlAdminPassword = "12345"
+$SQLStrongPassword = "Str0NgPA33w0rd!!" # Used for all other services
 
 # XConnect Parameters
 $XConnectConfiguration = "$AssetsRoot\xconnect-xp0.json"
@@ -31,7 +32,7 @@ $XConnectCert = "$SolutionPrefix.$SitePostFix.xConnect.Client"
 $XConnectSiteRoot = Join-Path $webroot -ChildPath $XConnectSiteName
 $XConnectSqlCollectionUser = "collectionuser"
 $XConnectSqlCollectionPassword = "Test12345"
-
+$SQLStrongPassword = "Str0NgPA33w0rd!!"
 # Sitecore Parameters
 $SitecoreSolrConfiguration = "$AssetsRoot\sitecore-solr.json"
 $SitecoreConfiguration = "$AssetsRoot\sitecore-xp0.json"

--- a/settings.ps1
+++ b/settings.ps1
@@ -32,7 +32,7 @@ $XConnectCert = "$SolutionPrefix.$SitePostFix.xConnect.Client"
 $XConnectSiteRoot = Join-Path $webroot -ChildPath $XConnectSiteName
 $XConnectSqlCollectionUser = "collectionuser"
 $XConnectSqlCollectionPassword = "Test12345"
-$SQLStrongPassword = "Str0NgPA33w0rd!!"
+
 # Sitecore Parameters
 $SitecoreSolrConfiguration = "$AssetsRoot\sitecore-solr.json"
 $SitecoreConfiguration = "$AssetsRoot\sitecore-xp0.json"


### PR DESCRIPTION
Meant to resolve #437 

Single strong password in settings.ps1 can easily be replaced by multiples. Install-SitecoreConfiguration calls use the same strong password - but it's better than Test12345 in the XP0.json files.

Installed from scratch