### PR TITLE
Removed redundant keystore file validation

### DIFF
--- a/build/GenerateSolrCertificate.ps1
+++ b/build/GenerateSolrCertificate.ps1
@@ -1,8 +1,13 @@
 . $PSScriptRoot\..\settings.ps1
 
+#File is automatically created
 $SolrKeyFile = "$SolrRoot\server\etc\solr-ssl.keystore.jks"
-if ((Test-Path($SolrKeyFile))) {
-	$SolrUri = [System.Uri]$SolrUrl
-	
-	. $PSScriptRoot\Certificates\solr-ssl.ps1 -KeystoreFile "$SolrKeyFile" -SolrDomain $SolrUri.Host -Clobber
-}
+
+#Get Solr configurations 
+$SolrUri = [System.Uri]$SolrUrl
+
+#Show Solr configurations
+echo $SolrUri
+
+#Generate keystore
+. $PSScriptRoot\Certificates\solr-ssl.ps1 -KeystoreFile "$SolrKeyFile" -SolrDomain $SolrUri.Host -Clobber


### PR DESCRIPTION
The script didn't show any errors so it was unclear if the script generated the keystore, if the keystore file doesn't exist the script will create it automatically.