### PR TITLE
Feature/msbuild

### DIFF
--- a/Habitat.sln
+++ b/Habitat.sln
@@ -199,6 +199,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Feature.Accounts.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Feature.Demo.Tests", "src\Feature\Demo\tests\Sitecore.Feature.Demo.Tests.csproj", "{0CF1F7D9-121A-4E40-844C-612EC40345F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebRoot", "src\WebRoot\WebRoot.csproj", "{7985416B-3C47-4ABF-8603-73CAB10BEB03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -613,6 +615,14 @@ Global
 		{0CF1F7D9-121A-4E40-844C-612EC40345F5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0CF1F7D9-121A-4E40-844C-612EC40345F5}.Release|x64.ActiveCfg = Release|Any CPU
 		{0CF1F7D9-121A-4E40-844C-612EC40345F5}.Release|x64.Build.0 = Release|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Debug|x64.Build.0 = Debug|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Release|x64.ActiveCfg = Release|Any CPU
+		{7985416B-3C47-4ABF-8603-73CAB10BEB03}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/publishsettings.targets
+++ b/publishsettings.targets
@@ -1,6 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <publishUrl>http://habitat.dev.local</publishUrl>
+        <publishUrl>C:\inetpub\wwwroot\habitat.dev.local</publishUrl>
         <ExcludeFilesFromDeployment>packages.config</ExcludeFilesFromDeployment>
     </PropertyGroup>
     <Import Project="./publishsettings.targets.user" Condition="exists('./publishsettings.targets.user')" /> 

--- a/src/Feature/Accounts/code/Sitecore.Feature.Accounts.csproj
+++ b/src/Feature/Accounts/code/Sitecore.Feature.Accounts.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -109,7 +109,10 @@
     <Content Include="App_Config\Include\Feature\Feature.Accounts.config">
       <SubType>Designer</SubType>
     </Content>
-    <None Include="App_Config\Security\Domains.config.xdt" />
+    <None Include="App_Config\Security\Domains.config.xdt">
+      <ApplyTransformOnPublish>True</ApplyTransformOnPublish>
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\PublishProfiles\Standalone.pubxml" />
     <Content Include="Scripts\Accounts\Accounts.js" />
     <Content Include="Views\Accounts\Login.cshtml" />

--- a/src/Foundation/Accounts/code/Sitecore.Foundation.Accounts.csproj
+++ b/src/Foundation/Accounts/code/Sitecore.Foundation.Accounts.csproj
@@ -115,7 +115,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_Config\Include\Foundation\Foundation.Accounts.config" />
-    <None Include="App_Config\Security\domains.config.xdt" />
+    <None Include="App_Config\Security\Domains.config.xdt">
+      <ApplyTransformOnPublish>true</ApplyTransformOnPublish>
+    </None>
     <None Include="Properties\PublishProfiles\Standalone.pubxml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/src/Foundation/SitecoreExtensions/code/Sitecore.Foundation.SitecoreExtensions.csproj
+++ b/src/Foundation/SitecoreExtensions/code/Sitecore.Foundation.SitecoreExtensions.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -131,9 +131,14 @@
       <SubType>Designer</SubType>
     </Content>
     <Content Include="App_Config\Include\Foundation\Foundation.SitecoreExtensions.Serialization.config" />
-    <None Include="App_Config\layers.config.xdt" />
+    <None Include="App_Config\Layers.config.xdt">
+      <ApplyTransformOnPublish>true</ApplyTransformOnPublish>
+    </None>
     <None Include="web.config" />
     <None Include="Properties\PublishProfiles\Standalone.pubxml" />
+    <None Include="Web.config.xdt">
+      <ApplyTransformOnPublish>true</ApplyTransformOnPublish>
+    </None>
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/src/Project/Habitat/code/Sitecore.Habitat.Website.csproj
+++ b/src/Project/Habitat/code/Sitecore.Habitat.Website.csproj
@@ -110,7 +110,9 @@
       <SubType>Designer</SubType>
     </Content>
     <Content Include="favicon.ico" />
-    <None Include="App_Config\layers.config.xdt" />
+    <None Include="App_Config\Layers.config.xdt">
+      <ApplyTransformOnPublish>true</ApplyTransformOnPublish>
+    </None>
     <None Include="App_Data\packages\Habitat.xml" />
     <None Include="Properties\PublishProfiles\Standalone.pubxml" />
     <Content Include="App_Config\Environment\Project\Habitat.Dev.config">

--- a/src/WebRoot/Helix.Module.targets
+++ b/src/WebRoot/Helix.Module.targets
@@ -1,0 +1,21 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    
+    <!--Default values -->
+    <ItemDefinitionGroup>
+        <None>
+            <ApplyTransformOnPublish>false</ApplyTransformOnPublish>
+        </None>
+    </ItemDefinitionGroup>
+
+    <Target
+        Name="GetTransformFilesToApplyOnPublish"
+        DependsOnTargets="PrepareForBuild;AssignTargetPaths"
+        Returns="@(_TransformFilesToApplyOnPublish)">
+
+        <ItemGroup>
+            <_TransformFilesToApplyOnPublish Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(ApplyTransformOnPublish)' == 'true'"/>
+        </ItemGroup>
+
+    </Target>
+
+</Project>

--- a/src/WebRoot/Helix.targets
+++ b/src/WebRoot/Helix.targets
@@ -1,0 +1,23 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <PipelineCollectFilesPhaseDependsOn>
+            $(PipelineCollectFilesPhaseDependsOn);
+            CollectContentFilesFromHelixModules;
+        </PipelineCollectFilesPhaseDependsOn>
+    </PropertyGroup>
+
+    <Target Name="CollectContentFilesFromHelixModules">
+        <MSBuild Projects="@(ProjectReference)" Targets="ContentFilesProjectOutputGroup" BuildInParallel="$(BuildInParallel)">
+            <Output TaskParameter="TargetOutputs" ItemName="_ContentFilesFromHelixModules" />
+        </MSBuild>
+        <ItemGroup>
+            <ContentFilesFromHelixModules Include="@(_ContentFilesFromHelixModules)">
+                <DestinationRelativePath>%(TargetPath)</DestinationRelativePath>
+            </ContentFilesFromHelixModules>
+
+            <FilesForPackagingFromProject Include="@(ContentFilesFromHelixModules)" /> 
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/src/WebRoot/Helix.targets
+++ b/src/WebRoot/Helix.targets
@@ -1,5 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <!-- Content Files-->
+
     <PropertyGroup>
         <PipelineCollectFilesPhaseDependsOn>
             $(PipelineCollectFilesPhaseDependsOn);
@@ -9,15 +11,66 @@
 
     <Target Name="CollectContentFilesFromHelixModules">
         <MSBuild Projects="@(ProjectReference)" Targets="ContentFilesProjectOutputGroup" BuildInParallel="$(BuildInParallel)">
-            <Output TaskParameter="TargetOutputs" ItemName="_ContentFilesFromHelixModules" />
+            <Output TaskParameter="TargetOutputs" ItemName="ContentFilesFromHelixModules" />
         </MSBuild>
         <ItemGroup>
-            <ContentFilesFromHelixModules Include="@(_ContentFilesFromHelixModules)">
+            <ContentFilesFromHelixModules>
                 <DestinationRelativePath>%(TargetPath)</DestinationRelativePath>
             </ContentFilesFromHelixModules>
 
-            <FilesForPackagingFromProject Include="@(ContentFilesFromHelixModules)" /> 
+            <FilesForPackagingFromProject Include="@(ContentFilesFromHelixModules)" />
         </ItemGroup>
+    </Target>
+
+    <!-- Transform Files (extending Slow Cheetah)-->
+
+    <PropertyGroup>
+        <PipelineCollectFilesPhaseDependsOn>
+            $(PipelineCollectFilesPhaseDependsOn);
+            CollectTransformFilesToApplyOnPublish;
+        </PipelineCollectFilesPhaseDependsOn>
+    </PropertyGroup>
+
+    <Target Name="CollectTransformFilesToApplyOnPublish">
+        <MSBuild Projects="@(ProjectReference)" Targets="GetTransformFilesToApplyOnPublish" BuildInParallel="$(BuildInParallel)" Properties="CustomBeforeMicrosoftCSharpTargets=$(MSBuildThisFileDirectory)Helix.Module.targets">
+            <Output TaskParameter="TargetOutputs" ItemName="TransformFilesToApplyOnPublish" />
+        </MSBuild>
+
+        <ItemGroup>
+            <TransformFilesToApplyOnPublish>
+                <TransformFile>%(FullPath)</TransformFile>
+                <TargetPathToFileToTransform>$([System.IO.Path]::Combine($([System.IO.Path]::GetDirectoryName(%(TargetPath))),%(Filename)))</TargetPathToFileToTransform>
+            </TransformFilesToApplyOnPublish>
+
+            <TransformFilesToApplyOnPublish>
+                <DestinationFileInPackageDir>$(_PackageTempDir)\%(TargetPathToFileToTransform)</DestinationFileInPackageDir>
+                <DestinationFileInPublishDir>$(PublishUrl)\%(TargetPathToFileToTransform)</DestinationFileInPublishDir>
+            </TransformFilesToApplyOnPublish>
+        </ItemGroup>
+
+        <Message Text="Transform file to apply on publish: %(TransformFilesToApplyOnPublish.TransformFile) %(DestinationFileInPackageDir) %(DestinationFileInPublishDir)" Importance="normal" Condition="@(TransformFilesToApplyOnPublish) != ''"/>
+
+        <ItemGroup>
+            <FilesToCopyFromPublishDirToPackageDir Include="@(TransformFilesToApplyOnPublish -> '%(DestinationFileInPublishDir)')" Condition="Exists('%(DestinationFileInPublishDir)')">
+                <DestinationRelativePath>%(TargetPathToFileToTransform)</DestinationRelativePath>
+            </FilesToCopyFromPublishDirToPackageDir>
+            <FilesToCopyFromPublishDirToPackageDir Remove="@(FilesToCopyFromPublishDirToPackageDir)" Condition="@(FilesToCopyFromPublishDirToPackageDir) != '' and @(FilesForPackagingFromProject) != '' and %(DestinationRelativePath) != ''"/>
+
+            <FilesForPackagingFromProject Include="@(FilesToCopyFromPublishDirToPackageDir)" Condition=""/>
+        </ItemGroup>
+
+        <Message Text="File copied to package dir: %(FilesToCopyFromPublishDirToPackageDir.Identity)" Importance="normal" Condition="@(FilesToCopyFromPublishDirToPackageDir) != ''"/>
+    </Target>
+
+    <Target Name="ApplyTransformsOnPublish" AfterTargets="ScApplyWebTransforms" DependsOnTargets="CollectTransformFilesToApplyOnPublish">
+
+        <SlowCheetah.TransformTask Source="%(TransformFilesToApplyOnPublish.DestinationFileInPackageDir)"
+                                   Transform="%(TransformFile)"
+                                   Destination="%(DestinationFileInPackageDir)"
+                                   Condition="Exists('%(TransformFile)') and Exists('%(DestinationFileInPackageDir)')" />
+
+        <Message Text="Transformed %(TransformFilesToApplyOnPublish.DestinationFileInPackageDir) using %(TransformFile) into %(DestinationFileInPackageDir)" Importance="high" Condition="Exists('%(TransformFile)') and Exists('%(DestinationFileInPackageDir)')"/>
+
     </Target>
 
 </Project>

--- a/src/WebRoot/Properties/AssemblyInfo.cs
+++ b/src/WebRoot/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebRoot")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebRoot")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7985416b-3c47-4abf-8603-73cab10beb03")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/WebRoot/Properties/PublishProfiles/Habitat.pubxml
+++ b/src/WebRoot/Properties/PublishProfiles/Habitat.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\publishsettings.targets" />
+
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/src/WebRoot/Web.Debug.config
+++ b/src/WebRoot/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/WebRoot/Web.Release.config
+++ b/src/WebRoot/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/WebRoot/Web.config
+++ b/src/WebRoot/Web.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.7.2"/>
+    <httpRuntime targetFramework="4.7.2"/>
+  </system.web>
+
+</configuration>

--- a/src/WebRoot/WebRoot.csproj
+++ b/src/WebRoot/WebRoot.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -196,10 +196,19 @@
       <Project>{c98ead78-4d83-4789-a621-6011c3d7314d}</Project>
       <Name>Sitecore.Common.Website</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Project\Habitat\code\Sitecore.Habitat.Website.csproj">
+      <Project>{86cadb26-5817-46b6-88c7-76d5753722c3}</Project>
+      <Name>Sitecore.Habitat.Website</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
       <Version>2.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SlowCheetah">
+      <Version>3.1.66</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/WebRoot/WebRoot.csproj
+++ b/src/WebRoot/WebRoot.csproj
@@ -1,0 +1,238 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7985416B-3C47-4ABF-8603-73CAB10BEB03}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebRoot</RootNamespace>
+    <AssemblyName>WebRoot</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Properties\PublishProfiles\Habitat.pubxml" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\feature\Accounts\code\Sitecore.Feature.Accounts.csproj">
+      <Project>{3f61c57d-50d9-4194-8196-ef5f7aa4cce5}</Project>
+      <Name>Sitecore.Feature.Accounts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Feature\demo\code\Sitecore.Feature.Demo.csproj">
+      <Project>{4dd516f2-d9e5-4775-b840-e00a71dd7e87}</Project>
+      <Name>Sitecore.Feature.Demo</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Feature\faq\code\Sitecore.Feature.FAQ.csproj">
+      <Project>{c2e10220-2850-484f-8fca-dcdd1c6e3b53}</Project>
+      <Name>Sitecore.Feature.FAQ</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Identity\code\Sitecore.Feature.Identity.csproj">
+      <Project>{0d0b809c-03ab-4ee1-898f-cfe28cf5b245}</Project>
+      <Name>Sitecore.Feature.Identity</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Language\code\Sitecore.Feature.Language.csproj">
+      <Project>{aca65632-ee93-422b-b25e-8e31969694f5}</Project>
+      <Name>Sitecore.Feature.Language</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Feature\Maps\code\Sitecore.Feature.Maps.csproj">
+      <Project>{19ce4259-bd16-4239-ac7c-22220fb26575}</Project>
+      <Name>Sitecore.Feature.Maps</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Media\code\Sitecore.Feature.Media.csproj">
+      <Project>{1417b162-f987-4cbd-8642-ca4c4119e705}</Project>
+      <Name>Sitecore.Feature.Media</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Metadata\code\Sitecore.Feature.Metadata.csproj">
+      <Project>{2bbd157c-ad28-4055-a208-48a2da93bd04}</Project>
+      <Name>Sitecore.Feature.Metadata</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Feature\Multisite\code\Sitecore.Feature.Multisite.csproj">
+      <Project>{64cb17ee-49bf-44a6-98f0-4f72ee89073b}</Project>
+      <Name>Sitecore.Feature.Multisite</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Navigation\code\Sitecore.Feature.Navigation.csproj">
+      <Project>{16003e7f-0faf-4dee-b13d-dd327e965a98}</Project>
+      <Name>Sitecore.Feature.Navigation</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\News\code\Sitecore.Feature.News.csproj">
+      <Project>{1aad6f22-9b6d-4688-8ea5-1ae7044031f7}</Project>
+      <Name>Sitecore.Feature.News</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\PageContent\code\Sitecore.Feature.PageContent.csproj">
+      <Project>{da079e95-db53-4a66-ab35-2dab71d19276}</Project>
+      <Name>Sitecore.Feature.PageContent</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Feature\Person\code\Sitecore.Feature.Person.csproj">
+      <Project>{452c63b5-6019-4ec2-9a9b-9b5dd3241485}</Project>
+      <Name>Sitecore.Feature.Person</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Search\code\Sitecore.Feature.Search.csproj">
+      <Project>{55b9c026-e106-4185-8213-9cdd53b44e1b}</Project>
+      <Name>Sitecore.Feature.Search</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Social\code\Sitecore.Feature.Social.csproj">
+      <Project>{b018c183-6976-4766-b2c0-0cba4c064aed}</Project>
+      <Name>Sitecore.Feature.Social</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\feature\Teasers\code\Sitecore.Feature.Teasers.csproj">
+      <Project>{64c1c1ef-71cb-47bd-92f9-4e50ce35bd9f}</Project>
+      <Name>Sitecore.Feature.Teasers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\Accounts\code\Sitecore.Foundation.Accounts.csproj">
+      <Project>{ce34a3b7-b91a-41ba-8b16-c1e131e1c621}</Project>
+      <Name>Sitecore.Foundation.Accounts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\Alerts\code\Sitecore.Foundation.Alerts.csproj">
+      <Project>{5cf5fa06-ab27-4df5-a471-ed57ef3e4ae9}</Project>
+      <Name>Sitecore.Foundation.Alerts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\foundation\Assets\code\Sitecore.Foundation.Assets.csproj">
+      <Project>{7e46ff93-ee05-412c-ac47-2a59a13da73c}</Project>
+      <Name>Sitecore.Foundation.Assets</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\DependencyInjection\code\Sitecore.Foundation.DependencyInjection.csproj">
+      <Project>{366148b7-2392-4f42-80d6-786b7a3682ae}</Project>
+      <Name>Sitecore.Foundation.DependencyInjection</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\Dictionary\code\Sitecore.Foundation.Dictionary.csproj">
+      <Project>{0d6ba4d8-c469-4ae9-9ebb-93bdf7d7e78f}</Project>
+      <Name>Sitecore.Foundation.Dictionary</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\FieldEditor\code\Sitecore.Foundation.FieldEditor.csproj">
+      <Project>{812c16c9-1e8a-42dc-a1c0-6896d570f63a}</Project>
+      <Name>Sitecore.Foundation.FieldEditor</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\foundation\Indexing\code\Sitecore.Foundation.Indexing.csproj">
+      <Project>{80213f24-577f-4f0b-a3b8-62485ea4d2f3}</Project>
+      <Name>Sitecore.Foundation.Indexing</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\Installer\code\Sitecore.Foundation.Installer.csproj">
+      <Project>{622ebd86-43a5-4857-965c-1724f714012a}</Project>
+      <Name>Sitecore.Foundation.Installer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\LocalDatasource\code\Sitecore.Foundation.LocalDatasource.csproj">
+      <Project>{323ca7a6-6abb-4652-abe2-75dab139cbc0}</Project>
+      <Name>Sitecore.Foundation.LocalDatasource</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\Multisite\code\Sitecore.Foundation.Multisite.csproj">
+      <Project>{cfa2ae87-7f8d-4ca6-bb72-b16380190db7}</Project>
+      <Name>Sitecore.Foundation.Multisite</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\foundation\Serialization\code\Sitecore.Foundation.Serialization.csproj">
+      <Project>{007cd5dc-0030-460d-91a3-3ddea9ab472f}</Project>
+      <Name>Sitecore.Foundation.Serialization</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\foundation\SitecoreExtensions\code\Sitecore.Foundation.SitecoreExtensions.csproj">
+      <Project>{b535703f-8d07-4f23-a533-2974bb4cc7b1}</Project>
+      <Name>Sitecore.Foundation.SitecoreExtensions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Foundation\Theming\code\Sitecore.Foundation.Theming.csproj">
+      <Project>{98de0d1d-26f1-4cca-847c-4e0fc2dba5fc}</Project>
+      <Name>Sitecore.Foundation.Theming</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Project\Common\code\Sitecore.Common.Website.csproj">
+      <Project>{c98ead78-4d83-4789-a621-6011c3d7314d}</Project>
+      <Name>Sitecore.Common.Website</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <Version>2.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Import Project="Helix.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>50303</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:57741/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/WebRoot/WebRoot.csproj
+++ b/src/WebRoot/WebRoot.csproj
@@ -210,6 +210,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Unicorn.MSBuild">
+      <Version>1.0.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/WebRoot/WebRoot.wpp.targets
+++ b/src/WebRoot/WebRoot.wpp.targets
@@ -1,0 +1,7 @@
+﻿<Project>
+    <!-- Unicorn Settings -->
+    <PropertyGroup>
+        <UnicornControlPanelUrl>https://habitat.sc/unicorn.aspx</UnicornControlPanelUrl>
+        <UnicornSharedSecret>749CABBC85EAD20CE55E2C6066F1BE375D2115696C8A8B24DB6ED1FD60613086</UnicornSharedSecret>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
I created extension for MSBuild that allows to build and publish Habitat the same way as gulp script does.

I described everything here on my blog. There are 6 articles so far in the MSBuild series: https://bartlomiejmucha.com/en/blog/msbuild/msbuild-basics-for-sitecore-devs/

I think that extending MSBuild to build and publish Helix projects is the right way (and works faster than gulp scripts).

I don't claim it's a complete feature. There will be probably some issues to fix, and I also need to do some tweaks for VSTS, however, It would be great if this could be maintained and improved in the main repository.

Please let me know what you think.