### PR TITLE
Add missing 'return' keyword

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -325,7 +325,7 @@ gulp.task("Auto-Publish-Assemblies",
         var roots = [root + "/**/code/**/bin"];
         var files = "/**/Sitecore.{Feature,Foundation,Habitat}.*.{dll,pdb}";;
         var destination = config.websiteRoot + "/bin/";
-        gulp.src(roots, { base: root }).pipe(
+        return gulp.src(roots, { base: root }).pipe(
             foreach(function(stream, rootFolder) {
                 gulp.watch(rootFolder.path + files,
                     function(event) {


### PR DESCRIPTION
Fixes bug causing gulp.watch() to monitor only the first 16 bin folders found in the solution