### PR TITLE
Update unicorn.js

### DIFF
--- a/scripts/unicorn.js
+++ b/scripts/unicorn.js
@@ -38,9 +38,9 @@ module.exports = function (callback, options) {
   var url = siteHostName + "/unicorn.aspx";
 
 
-  var syncScript =__dirname + "/Unicorn/./Sync.ps1 -secret " + secret + " -url " + url;
+  var syncScript = `"./Sync.ps1" -secret ${secret} -url "${url}"`;
   var options = { cwd: __dirname + "/Unicorn/", maxBuffer: 1024 * 500 };
-  var process = exec("powershell -executionpolicy unrestricted \"" + syncScript + "\"", options, function (err, stdout, stderr) {
+  var process = exec(`powershell -executionpolicy unrestricted ${syncScript}`, options, function (err, stdout, stderr) {
     if (err !== null) throw err;
     console.log(stdout);
     callback();


### PR DESCRIPTION
Replace Sync.ps1 absolute path with relative.
Since there is already `cwd` passed to the `exec` as option we don't need to specify full path to the script

https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

https://github.com/Sitecore/Habitat/issues/323