### PR TITLE
Fixed Multisite current site evaluation issue: the site selector does…

### DIFF
--- a/src/Feature/Language/Tests/LanguageRepositoryTests.cs
+++ b/src/Feature/Language/Tests/LanguageRepositoryTests.cs
@@ -75,7 +75,7 @@
       linkManager.Setup(x => x.GetItemUrl(contextItem, It.IsAny<UrlOptions>())).Returns(url);
 
       var siteContext = new Mock<Foundation.Multisite.SiteContext>(siteProvider);
-      siteContext.Setup(x => x.GetSiteDefinition(contextItem)).Returns(new SiteDefinition
+      siteContext.Setup(x => x.GetSiteDefinition(contextItem)).Returns(new SiteDefinition(siteInfo => true)
       {
           Item = db.GetItem(siteRootId)
       });
@@ -122,7 +122,7 @@
       var contextItem = db.GetItem(item.ID);
 
       var siteContext = new Mock<Foundation.Multisite.SiteContext>(siteProvider);
-      siteContext.Setup(x => x.GetSiteDefinition(contextItem)).Returns(new SiteDefinition
+      siteContext.Setup(x => x.GetSiteDefinition(contextItem)).Returns(new SiteDefinition(siteInfo => true)
       {
           Item = db.GetItem(siteRootId)
       });

--- a/src/Feature/Multisite/tests/SiteConfigurationRepositoryTests.cs
+++ b/src/Feature/Multisite/tests/SiteConfigurationRepositoryTests.cs
@@ -46,7 +46,7 @@
                            {"name", name},
                          };
 
-            siteDefinitionProvider.SiteDefinitions.Returns(new List<SiteDefinition> {new SiteDefinition {Item = item, Site = new SiteInfo(siteSettings) } });
+            siteDefinitionProvider.SiteDefinitions.Returns(new List<SiteDefinition> {new SiteDefinition (siteInfo => true) {Item = item, Site = new SiteInfo(siteSettings) } });
             var definitions = repository.Get();
             definitions.Should().BeOfType<SiteConfigurations>();
             var sites = definitions.Items.ToList();

--- a/src/Foundation/Multisite/code/Providers/SiteDefinitionsProvider.cs
+++ b/src/Foundation/Multisite/code/Providers/SiteDefinitionsProvider.cs
@@ -62,12 +62,11 @@
             }
 
             var siteItem = this.GetSiteRootItem(site);
-            return new SiteDefinition
-            {
+            return new SiteDefinition(this.IsCurrent)
+            { 
                 Item = siteItem,
                 Name = site.Name,
                 HostName = GetHostName(site),
-                IsCurrent = this.IsCurrent(site),
                 Site = site
             };
         }

--- a/src/Foundation/Multisite/code/SiteDefinition.cs
+++ b/src/Foundation/Multisite/code/SiteDefinition.cs
@@ -1,14 +1,22 @@
 ﻿namespace Sitecore.Foundation.Multisite
 {
-  using Sitecore.Data.Items;
-  using Sitecore.Web;
+    using System;
+    using Sitecore.Data.Items;
+    using Sitecore.Web;
 
-  public class SiteDefinition
-  {
-    public Item Item { get; set; }
-    public string HostName { get; set; }
-    public string Name { get; set; }
-    public bool IsCurrent { get; set; }
-    public SiteInfo Site { get; set; }
-  }
+    public class SiteDefinition
+    {
+        private readonly Func<SiteInfo, bool> isCurrentSiteFunc;
+
+        public SiteDefinition(Func<SiteInfo, bool> isCurrentSiteFunc)
+        {
+            this.isCurrentSiteFunc = isCurrentSiteFunc;
+        }
+
+        public Item Item { get; set; }
+        public string HostName { get; set; }
+        public string Name { get; set; }
+        public bool IsCurrent => this.isCurrentSiteFunc(this.Site);
+        public SiteInfo Site { get; set; }
+    }
 }

--- a/src/Foundation/Multisite/tests/SiteContextTests.cs
+++ b/src/Foundation/Multisite/tests/SiteContextTests.cs
@@ -24,8 +24,7 @@
       db.Add(new DbItem(siteName, siteDefinitionId, Templates.Site.ID) { item });
       var definitionItem = db.GetItem(siteDefinitionId);
 
-      var definition = new SiteDefinition();
-      definition.Item = definitionItem;
+      var definition = new SiteDefinition(siteInfo => true) {Item = definitionItem};
       provider.GetContextSiteDefinition(Arg.Any<Item>()).Returns(definition);
 
       var siteContext = new SiteContext(provider);

--- a/src/Foundation/Multisite/tests/SiteSettingsProviderTests.cs
+++ b/src/Foundation/Multisite/tests/SiteSettingsProviderTests.cs
@@ -37,7 +37,7 @@
              });
       var definitionItem = db.GetItem(definitionId);
       var setting = db.GetItem(settingItemId);
-      context.GetSiteDefinition(Arg.Any<Item>()).Returns(new SiteDefinition {Item = definitionItem });
+      context.GetSiteDefinition(Arg.Any<Item>()).Returns(new SiteDefinition(siteInfo => true) { Item = definitionItem });
       var settingItem = provider.GetSetting(contextItem, DatasourceProvider.DatasourceSettingsName, settingName);
       settingItem.ID.Should().BeEquivalentTo(setting.ID);
     }


### PR DESCRIPTION
Fixed Multisite current site evaluation issue: the site selector does not show the current site selection based on the current Site context.

Implementation note: maybe SiteDefinition should just have the corresponding extension method instead of "IsCurrent" property. Then the extension method can be unit tested in isolation. However, it would make the coding less intuitive because you will not observe the extension method from IntelliSense unless the extension method class's namespace is exposed to the context.
