### PR TITLE
Changing structures to static classes to store template references

### DIFF
--- a/src/Feature/Accounts/code/Templates.cs
+++ b/src/Feature/Accounts/code/Templates.cs
@@ -2,13 +2,13 @@
 {
     using Sitecore.Data;
 
-    public struct Templates
+    public static class Templates
     {
-        public struct AccountsSettings
+        public static class AccountsSettings
         {
             public static readonly ID ID = new ID("{59D216D1-035C-4497-97B4-E3C5E9F1C06B}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID AccountsDetailsPage = new ID("{ED71D374-8C33-4561-991D-77482AE01330}");
                 public static readonly ID RegisterPage = new ID("{71962360-10D8-4B98-BB8D-57660CE11127}");
@@ -20,11 +20,11 @@
             }
         }
 
-        public struct MailTemplate
+        public static class MailTemplate
         {
             public static readonly ID ID = new ID("{26DF8F38-7E1B-43D2-85DD-68DF05FA276B}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID From = new ID("{8605948C-60FB-46B8-8AAA-4C52561B53BC}");
                 public static readonly ID Subject = new ID("{0F45DF05-546F-462D-97C0-BA4FB2B02564}");
@@ -32,32 +32,32 @@
             }
         }
 
-        public struct Interest
+        public static class Interest
         {
             public static readonly ID ID = new ID("{C9B1855E-CA80-4414-B5BA-956CB67DC5A9}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID Title = new ID("{1FBE5200-2C62-4A32-BA84-CFFE3CF665D3}");
             }
         }
 
-        public struct ProfileSettigs
+        public static class ProfileSettigs
         {
             public static readonly ID ID = new ID("{2D9AA1E4-3359-4F02-9EAA-5CF972FD990D}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID UserProfile = new ID("{378B7D87-5775-4EB6-86B7-282D5359B1C6}");
                 public static readonly ID InterestsFolder = new ID("{021AA3F7-206F-4ACC-9538-F6D7FE86B168}");
             }
         }
 
-        public struct UserProfile
+        public static class UserProfile
         {
             public static readonly ID ID = new ID("{696D276B-786A-4D1E-B8BB-8E139DB7BE7C}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID FirstName = new ID("{E7BC8A3E-3201-4556-B2FF-FF4DB04DB081}");
                 public static readonly ID LastName = new ID("{EE21278F-4F83-4A10-8890-66B957F3D312}");
@@ -66,11 +66,11 @@
             }
         }
 
-        public struct LoginTeaser
+        public static class LoginTeaser
         {
             public static readonly ID ID = new ID("{EF38D9E6-313C-491C-8648-79436D10091C}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID Title = new ID("{D9843186-ED10-47D8-8CC7-511AC670B6B4}");
                 public static readonly ID Summary = new ID("{FFAB401B-8D7C-4172-A82A-AE32B7D2C6C1}");

--- a/src/Feature/Demo/code/Templates.cs
+++ b/src/Feature/Demo/code/Templates.cs
@@ -2,23 +2,23 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct ProfilingSettings
+    public static class ProfilingSettings
     {
       public static readonly ID ID = new ID("{C6D4DDD5-B912-4C1A-A3A3-E1D90E4D0939}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID SiteProfiles = new ID("{2A84ECA4-68BB-4451-B4AC-98EA71A5A3DC}");
       }
     }
 
-    public struct DemoContent
+    public static class DemoContent
     {
       public static readonly ID ID = new ID("{1224B40E-7B6C-42B3-A6D0-C40A6C61345C}");
 
-      public struct Fields
+      public static class Fields
       {
                 public static readonly ID HtmlContent = new ID("{0BC0AEDF-A6D0-4F74-933C-BD1779CD40B2}");
                 public static readonly ID Referrer = new ID("{D28EFE17-C491-47C0-B62D-934DC9DA38A4}");
@@ -39,11 +39,11 @@
       }
     }
 
-    public struct Token
+    public static class Token
     {
       public static readonly ID ID = new ID("{A7EBF38A-5F66-4579-92D1-568A8BA50293}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly string TokenValue = "Token Value";
       }

--- a/src/Feature/Identity/code/Templates.cs
+++ b/src/Feature/Identity/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct Identity
+    public static class Identity
     {
       public static readonly ID ID = new ID("{FA8DE5B9-D5D8-40A7-866A-23AF4F5A9629}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Logo = new ID("{E748D808-64C1-4DEC-9718-F35CF9689E4B}");
         public static readonly ID LogoTagLine = new ID("{31D027BB-FAB5-4E1A-A66D-9F5B0FD4F005}");

--- a/src/Feature/Language/code/Templates.cs
+++ b/src/Feature/Language/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct LanguageSettings
+    public static class LanguageSettings
     {
       public static readonly ID ID = new ID("{748EBA96-3F0C-4F45-8AFB-DE8DCC707B84}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID SupportedLanguages = new ID("{5F115B6D-6052-4C7E-B442-AE923A7E9BD2}");
       }

--- a/src/Feature/Maps/code/Templates.cs
+++ b/src/Feature/Maps/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct MapPoint
+    public static class MapPoint
     {
       public static readonly ID ID = new ID("{1E6A8C8C-6646-4776-8AB4-615265669633}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Name = new ID("{F12C22BB-E57D-4FAB-96E1-1229E4E7FF0E}");
         public static readonly ID Address = new ID("{0295C01D-214C-4C23-AFC2-3F0B4E88B643}");
@@ -16,7 +16,7 @@
       }
     }
 
-    public struct MapPointsFolder
+    public static class MapPointsFolder
     {
       public static readonly ID ID = new ID("{31713995-C6BF-4CCB-8807-198493508AFA}");
     }

--- a/src/Feature/Media/code/Templates.cs
+++ b/src/Feature/Media/code/Templates.cs
@@ -2,23 +2,23 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct BackgroundType
+    public static class BackgroundType
     {
       public static readonly ID ID = new ID("{55A5BDAD-EB69-40F5-8195-CDA182E48EE4}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Class = new ID("{AF6B8E5C-10A2-46BE-8310-407434EC1055}");
       }
     }
 
-    public struct HasMedia
+    public static class HasMedia
     {
       public static readonly ID ID = new ID("{A44E450E-BA3F-4FAF-9C53-C63241CC34EB}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Title = new ID("{63DDA48B-B0CB-45A7-9A1B-B26DDB41009B}");
         public static readonly ID Description = new ID("{302C9F8D-F703-4F76-A4AB-73D222648232}");
@@ -26,31 +26,31 @@
       }
     }
 
-    public struct HasMediaSelector
+    public static class HasMediaSelector
     {
       public static readonly ID ID = new ID("{AE4635AF-CFBF-4BF6-9B50-00BE23A910C0}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID MediaSelector = new ID("{72EA8682-24D2-4BEB-951C-3E2164974105}");
       }
     }
 
-    public struct HasMediaImage
+    public static class HasMediaImage
     {
       public static readonly ID ID = new ID("{FAE0C913-1600-4EBA-95A9-4D6FD7407E25}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Image = new ID("{9F51DEAD-AD6E-41C2-9759-7BE17EB474A4}");
       }
     }
 
-    public struct HasMediaVideo
+    public static class HasMediaVideo
     {
       public static readonly ID ID = new ID("{5A1B724B-B396-4C48-A833-655CD19018E1}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID VideoLink = new ID("{2628705D-9434-4448-978C-C3BF166FA1EB}");
       }

--- a/src/Feature/Metadata/code/Templates.cs
+++ b/src/Feature/Metadata/code/Templates.cs
@@ -2,13 +2,13 @@
 {
     using Sitecore.Data;
 
-    public struct Templates
+    public static class Templates
     {
-        public struct PageMetadata
+        public static class PageMetadata
         {
             public static ID ID = new ID("{D88CCD80-D851-470D-AF11-701FF23504E7}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID BrowserTitle = new ID("{CA0479CE-0BFE-4522-83DE-BA688B380A78}");
                 public static readonly ID Description = new ID("{BB7A38C0-323C-4F81-8EB9-288ABF7C4638}");
@@ -19,21 +19,21 @@
             }
         }
 
-        public struct SiteMetadata
+        public static class SiteMetadata
         {
             public static readonly ID ID = new ID("{CF38E914-9298-47CC-9205-210553E79F97}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID SiteBrowserTitle = new ID("{235AE392-97AC-4822-BE38-837DA3E7724E}");
             }
         }
 
-        public struct Keyword
+        public static class Keyword
         {
             public static ID ID = new ID("{409F883A-0DC8-431A-9508-7316B59B92BE}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID Keyword = new ID("{7BDBBA5F-C7E6-45C2-82F5-010DED013588}");
             }

--- a/src/Feature/Multisite/code/Templates.cs
+++ b/src/Feature/Multisite/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public class Templates
+  public static class Templates
   {
-    public struct SiteConfiguration
+    public static class SiteConfiguration
     {
       public static readonly ID ID = new ID("{0FCCFE4F-B087-498F-BD26-5CDFFC522C9A}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID ShowInMenu = new ID("{12537182-F35C-403F-AFB5-747D55C450B8}");
         public static readonly ID Title = new ID("{F07811D3-41E9-440A-9D81-310C1D78BED6}");

--- a/src/Feature/Navigation/code/Templates.cs
+++ b/src/Feature/Navigation/code/Templates.cs
@@ -2,18 +2,18 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct NavigationRoot
+    public static class NavigationRoot
     {
       public static readonly ID ID = new ID("{F9F4FC05-98D0-4C62-860F-F08AE7F0EE25}");
     }
 
-    public struct Navigable
+    public static class Navigable
     {
       public static readonly ID ID = new ID("{A1CBA309-D22B-46D5-80F8-2972C185363F}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID ShowInNavigation = new ID("{5585A30D-B115-4753-93CE-422C3455DEB2}");
         public static readonly ID NavigationTitle = new ID("{1B483E91-D8C4-4D19-BA03-462074B55936}");
@@ -21,21 +21,21 @@
       }
     }
 
-    public struct Link
+    public static class Link
     {
       public static readonly ID ID = new ID("{A16B74E9-01B8-439C-B44E-42B3FB2EE14B}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Link = new ID("{FE71C30E-F07D-4052-8594-C3028CD76E1F}");
       }
     }
 
-    public struct LinkMenuItem
+    public static class LinkMenuItem
     {
       public static readonly ID ID = new ID("{18BAF6B0-E0D6-4CCE-9184-A4849343E7E4}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Icon = new ID("{2C24649E-4460-4114-B026-886CFBE1A96D}");
         public static readonly ID DividerBefore = new ID("{4231CD60-47C1-42AD-B838-0A6F8F1C4CFB}");

--- a/src/Feature/News/code/Templates.cs
+++ b/src/Feature/News/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct NewsArticle
+    public static class NewsArticle
     {
       public static readonly ID ID = new ID("{2F75C8AF-35FC-4A88-B585-7595203F442C}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Title = new ID("{BD9ECD4A-C0B0-4233-A3CD-D995519AC87B}");
         public const string Title_FieldName = "NewsTitle";
@@ -25,7 +25,7 @@
       }
     }
 
-    public struct NewsFolder
+    public static class NewsFolder
     {
       public static readonly ID ID = new ID("{74889B26-061C-4D6A-8CDB-422665FC34EC}");
     }

--- a/src/Feature/PageContent/code/Renderings.cs
+++ b/src/Feature/PageContent/code/Renderings.cs
@@ -2,7 +2,7 @@
 {
     using Sitecore.Data;
 
-    public struct Renderings
+    public static class Renderings
     {
         public static readonly ID PageTeaser = new ID("{07AB411C-F894-4144-B069-48EF67431D32}");
     }

--- a/src/Feature/PageContent/code/Templates.cs
+++ b/src/Feature/PageContent/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct HasPageContent
+    public static class HasPageContent
     {
       public static readonly ID ID = new ID("{AF74A00B-8CA7-4C9A-A5C1-156A68590EE2}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Title = new ID("{C30A013F-3CC8-4961-9837-1C483277084A}");
         public const string Title_FieldName = "Title";

--- a/src/Feature/Person/code/Templates.cs
+++ b/src/Feature/Person/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct Person
+    public static class Person
     {
       public static readonly ID ID = new ID("{7ACA6ECF-1A80-4E35-97F5-DBAA8E3EC617}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Name = new ID("{26CD59AB-3639-488F-BAFD-58D2B217755A}");
         public static readonly ID Title = new ID("{76972FCD-4BB0-4255-864E-077745EFDF50}");
@@ -20,22 +20,22 @@
       }
     }
 
-    public struct Quote
+    public static class Quote
     {
       public static readonly ID ID = new ID("{755F1188-D385-4717-8681-EF45F2258575}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID CiteOrigin = new ID("{BF83983A-473F-4A49-BE8E-7D563AA5687E}");
         public static readonly ID Quote = new ID("{0DE53078-0DA4-40CC-BBCA-63AA96A0A1EF}");
       }
     }
 
-    public struct Employee
+    public static class Employee
     {
       public static readonly ID ID = new ID("{745652AE-3298-48B1-9BE1-99012D91F3AC}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Biography = new ID("{0CC9785E-54FE-4FAE-93E4-D0D2AE75F339}");
         public static readonly ID Telephone = new ID("{8D0E8EE3-21C4-4AE2-A2F1-53D3F3EBE501}");

--- a/src/Feature/Search/code/Templates.cs
+++ b/src/Feature/Search/code/Templates.cs
@@ -2,13 +2,13 @@
 {
     using Sitecore.Data;
 
-    public struct Templates
+    public static class Templates
     {
-        public struct SearchResults
+        public static class SearchResults
         {
             public static readonly ID ID = new ID("{14E452CA-064D-48A8-9FF2-2744D10437A1}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID SearchBoxTitle = new ID("{80E30DD8-8021-45F5-9FE1-23D2702CC206}");
                 public static readonly ID Root = new ID("{CD904125-3AE5-4709-9E6D-71473C5D5007}");
@@ -16,11 +16,11 @@
             }
         }
 
-        public struct SearchContext
+        public static class SearchContext
         {
             public static readonly ID ID = new ID("{B524E8BE-A099-4A63-BE3F-DD4C42FD4185}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID SearchResultsPage = new ID("{1C843E6A-02B9-4AA0-9FED-FDFDDC419AE3}");
             }

--- a/src/Feature/Social/code/Templates.cs
+++ b/src/Feature/Social/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct OpenGraph
+    public static class OpenGraph
     {
       public static ID ID = new ID("{BDD24F35-05E8-4466-8798-7D3DD6A6C991}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Title = new ID("{0EE2F208-1FEE-42FC-8051-6696D49A92BF}");
         public static readonly ID Description = new ID("{A12D5346-87EE-484D-83C5-F1E8E1B99666}");
@@ -16,11 +16,11 @@
       }
     }
 
-    public struct TwitterFeed
+    public static class TwitterFeed
     {
       public static ID ID = new ID("{89D988BC-A9A7-43F5-A9FD-A05B0B164720}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID FeedTitle = new ID("{099E4085-150C-4073-88D9-8B159D9A8B01}");
         public static readonly ID TwitterUrl = new ID("{92EF8986-45E2-42DE-913F-B91FD960297A}");

--- a/src/Feature/Teasers/code/Templates.cs
+++ b/src/Feature/Teasers/code/Templates.cs
@@ -2,34 +2,34 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct DynamicTeaser
+    public static class DynamicTeaser
     {
       public static ID ID = new ID("{20A56D46-F5E3-4DB8-8B96-081575363D44}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Active = new ID("{9E942565-677F-491C-A0AC-6B930E37342A}");
         public static readonly ID Count = new ID("{A33F9523-96C4-4E42-B6D7-1E861718D373}");
       }
     }
 
-    public struct TeaserHeadline
+    public static class TeaserHeadline
     {
       public static ID ID = new ID("{C80D124B-B9AC-432E-8C26-DBF3A7F18D20}");
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Title = new ID("{4A59D072-5B41-4A79-A157-2B2CCAC10F2B}");
         public static readonly ID Icon = new ID("{3AF50903-63A9-464B-A375-B94983624E7D}");
       }
     }
 
-    public struct TeaserContent
+    public static class TeaserContent
     {
       public static ID ID = new ID("{FEC0E62A-01FD-40E5-88F3-E5229FE79527}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Label = new ID("{3F7E7E3A-4E8E-4639-B079-FC5AEFF172F5}");
         public static readonly ID Summary = new ID("{13D97A52-7C4E-407C-960D-FADDE8A3C1B1}");
@@ -38,21 +38,21 @@
       }
     }
 
-    public struct TeaserVideoContent
+    public static class TeaserVideoContent
     {
       public static ID ID = new ID("{04075EB6-6D94-4BF2-9AEB-D29A89CDBA00}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID VideoLink = new ID("{AC846A16-FD3F-4243-A21F-668A21010C44}");
       }
     }
 
-    public struct Icon
+    public static class Icon
     {
       public static ID ID = new ID("{E90D00B6-0BE9-48E0-9C3F-047274024270}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID CssClass = new ID("{585F89D1-570C-4F66-A6EC-195A8DA654E1}");
       }

--- a/src/Feature/faq/code/Templates.cs
+++ b/src/Feature/faq/code/Templates.cs
@@ -2,24 +2,24 @@
 {
   using Sitecore.Data;
 
-  public class Templates
+  public static class Templates
   {
-    public struct Faq
+    public static class Faq
     {
       public static readonly ID ID = new ID("{9544F0B3-FD5E-4301-9DDE-9E73D2C3F7BA}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Question = new ID("{9588B6D5-3E6A-4C16-BD37-98DA6F1DDE52}");
         public static readonly ID Answer = new ID("{57F39C75-51F0-4888-903E-724DFDCC8A38}");
       }
     }
 
-    public struct FaqGroup
+    public static class FaqGroup
     {
       public static readonly ID ID = new ID("{3AF7DB6C-A602-4ABC-8D63-19E2D2C6726B}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID GroupMember = new ID("{631DA648-E2A5-4E3B-9733-C9C066C41EAE}");
       }

--- a/src/Foundation/Assets/code/Templates.cs
+++ b/src/Foundation/Assets/code/Templates.cs
@@ -2,13 +2,13 @@
 {
     using Sitecore.Data;
 
-    public struct Templates
+    public static class Templates
     {
-        public struct RenderingAssets
+        public static class RenderingAssets
         {
             public static readonly ID ID = new ID("{7CEAC341-B953-4C69-B907-EE44302BF6AE}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID ScriptFiles = new ID("{E514A1EB-DDBA-44F7-8528-82CA2280F778}");
                 public static readonly ID StylingFiles = new ID("{4867D192-326A-4AA4-81EF-EA430E224AFF}");
@@ -17,11 +17,11 @@
             }
         }
 
-        public struct PageAssets
+        public static class PageAssets
         {
             public static readonly ID ID = new ID("{91962B60-25F6-428F-8D10-02AA1E49D6A5}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID JavascriptCodeTop = new ID("{D79D9DDD-2774-42F4-94C3-50C892F6E13D}");
                 public static readonly ID JavascriptCodeBottom = new ID("{B3BA9EA9-D0A1-49DF-9F4B-28FA5D353DC8}");
@@ -30,11 +30,11 @@
             }
         }
 
-        public struct HasTheme
+        public static class HasTheme
         {
             public static readonly ID ID = new ID("{5B6F8720-3A93-4DA1-92A0-C3E85E01219A}");
 
-            public struct Fields
+            public static class Fields
             {
                 public static readonly ID Theme = new ID("{53B5AF0A-265F-4E60-B2B2-4576CE0BECCF}");
             }

--- a/src/Foundation/Dictionary/code/Templates.cs
+++ b/src/Foundation/Dictionary/code/Templates.cs
@@ -2,26 +2,26 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct DictionaryFolder
+    public static class DictionaryFolder
     {
       public static ID ID => new ID("{98E4BDC6-9B43-4EB2-BAA3-D4303C35852E}");
     }
 
-    public struct DictionaryEntry
+    public static class DictionaryEntry
     {
       public static ID ID => new ID("{EC4DD3F2-590D-404B-9189-2A12679749CC}");
-      public struct Fields
+      public static class Fields
       {
         public static ID Phrase => new ID("{DDACDD55-5B08-405F-9E58-04F09AED640A}");
       }
     }
 
-    public struct DictionarySettings
+    public static class DictionarySettings
     {
       public static ID ID => new ID("{31D191DD-3FA1-4D2F-A348-7F315F72279F}");
-      public struct Fields
+      public static class Fields
       {
         public static ID DefaultLanguage => new ID("{36DB0022-5858-4CF7-9BCC-4C3ADC002FB3}");
       }

--- a/src/Foundation/Indexing/code/Templates.cs
+++ b/src/Foundation/Indexing/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  internal struct Templates
+  internal static class Templates
   {
-    internal struct IndexedItem
+    internal static class IndexedItem
     {
       public static ID ID = new ID("{8FD6C8B6-A9A4-4322-947E-90CE3D94916D}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID IncludeInSearchResults = new ID("{8D5C486E-A0E3-4DBE-9A4A-CDFF93594BDA}");
         public const string IncludeInSearchResults_FieldName = "IncludeInSearchResults";

--- a/src/Foundation/LocalDatasource/code/Templates.cs
+++ b/src/Foundation/LocalDatasource/code/Templates.cs
@@ -7,20 +7,20 @@ namespace Sitecore.Foundation.LocalDatasource
 {
   using Sitecore.Data;
 
-  public class Templates
+  public static class Templates
   {
-    public struct RenderingOptions
+    public static class RenderingOptions
     {
       public static ID ID = new ID("{D1592226-3898-4CE2-B190-090FD5F84A4C}");
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID SupportsLocalDatasource = new ID("{1C307764-806C-42F0-B7CE-FC173AC8372B}");
       }
     }
 
-    public struct Index
+    public static class Index
     {
-      public struct Fields
+      public static class Fields
       {
         public static readonly string LocalDatasourceContent_IndexFieldName = "local_datasource_content";
       }

--- a/src/Foundation/Multisite/code/Templates.cs
+++ b/src/Foundation/Multisite/code/Templates.cs
@@ -3,34 +3,34 @@
   using Sitecore.Data;
   using Sitecore.Shell.Framework.Commands.Masters;
 
-  public class Templates
+  public static class Templates
   {
-    public struct Site
+    public static class Site
     {
       public static ID ID = new ID("{BB85C5C2-9F87-48CE-8012-AF67CF4F765D}");
     }
 
-    public struct DatasourceConfiguration
+    public static class DatasourceConfiguration
     {
       public static ID ID = new ID("{C82DC5FF-09EF-4403-96D3-3CAF377B8C5B}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID DatasourceLocation = new ID("{5FE1CC43-F86C-459C-A379-CD75950D85AF}");
         public static readonly ID DatasourceTemplate = new ID("{498DD5B6-7DAE-44A7-9213-1D32596AD14F}");
       }
     }
 
-    public struct SiteSettings
+    public static class SiteSettings
     {
       public static ID ID = new ID("{BCCFEBEA-DCCB-48FE-9570-6503829EC03F}");
     }
 
-    public struct RenderingOptions
+    public static class RenderingOptions
     {
       public static ID ID = new ID("{D1592226-3898-4CE2-B190-090FD5F84A4C}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID DatasourceLocation = new ID("{B5B27AF1-25EF-405C-87CE-369B3A004016}");
         public static readonly ID DatasourceTemplate = new ID("{1A7C85E5-DC0B-490D-9187-BB1DBCB4C72F}");

--- a/src/Foundation/Theming/code/Templates.cs
+++ b/src/Foundation/Theming/code/Templates.cs
@@ -2,13 +2,13 @@
 {
   using Sitecore.Data;
 
-  public struct Templates
+  public static class Templates
   {
-    public struct Style
+    public static class Style
     {
       public static readonly ID ID = new ID("{C2AC5C42-A05C-4F51-854E-730C9BCA06D1}");
 
-      public struct Fields
+      public static class Fields
       {
         public static readonly ID Class = new ID("{CF1E34B0-27E7-4861-BECD-C0BC58295F77}");
       }


### PR DESCRIPTION
- **Templates** structures were changed to static classes to hold template GUIDs.

- It was discussed earlier, [here](https://github.com/Sitecore/Habitat/issues/458) and also in Sitecore Slack, 