### PR TITLE
[closes #476] Change approach to fixing System.Buffers reference issue

### DIFF
--- a/src/Project/Common/code/Directory.Build.props
+++ b/src/Project/Common/code/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+      Referencing in Directory.build.props will prevent Visual Studio from expanding the globs when you rename a project.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Foundation\*\code\*.csproj" />
+    <ProjectReference Include="..\..\..\Feature\*\code\*.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Project/Common/code/Web.config.xdt
+++ b/src/Project/Common/code/Web.config.xdt
@@ -2,10 +2,6 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <!-- Remove problematic assembly redirect found in 9.2. -->
-            <dependentAssembly xdt:Transform="RemoveAll"
-                               xdt:Locator="Condition(./_defaultNamespace:assemblyIdentity/@name='System.Buffers')"></dependentAssembly>
-
             <!-- Update aseembly binding to resolve 9.2 w3wp crash in some environments. Related to https://kb.sitecore.net/articles/494291 -->
             <dependentAssembly xdt:Transform="RemoveAll"
                                xdt:Locator="Condition(./_defaultNamespace:assemblyIdentity/@name='System.Security.Cryptography.Algorithms')"></dependentAssembly>

--- a/src/Project/Habitat/code/Sitecore.Habitat.Website.csproj
+++ b/src/Project/Habitat/code/Sitecore.Habitat.Website.csproj
@@ -62,6 +62,8 @@
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <!-- Need to explicitly reference to ensure compatible version: https://sitecore.stackexchange.com/questions/20379/sitecore-9-2-could-not-load-file-or-assembly-system-buffers-or-one-of-its-dep/20380#20380 -->
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel" Version="4.0.1" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
     <PackageReference Include="System.Globalization" Version="4.0.11" />
@@ -170,6 +172,10 @@
       <Project>{b535703f-8d07-4f23-a533-2974bb4cc7b1}</Project>
       <Name>Sitecore.Foundation.SitecoreExtensions</Name>
       <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Common\code\Sitecore.Common.Website.csproj">
+      <Project>{c98ead78-4d83-4789-a621-6011c3d7314d}</Project>
+      <Name>Sitecore.Common.Website</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
* Ensure we don't replace the version shipped with the product
* Add explicit reference to 4.5.0 in Project layer
* Ensure project dependencies are such that it's deployed last