### PR TITLE
Droptree standard value will come back as false when calling the field.HasValue method

### DIFF
--- a/src/Foundation/SitecoreExtensions/code/Extensions/ItemExtensions.cs
+++ b/src/Foundation/SitecoreExtensions/code/Extensions/ItemExtensions.cs
@@ -63,7 +63,7 @@
             {
                 throw new ArgumentNullException(nameof(item));
             }
-            if (item.Fields[linkFieldId] == null || !item.Fields[linkFieldId].HasValue)
+            if (item.Fields[linkFieldId] == null || !item.FieldHasValue(linkFieldId))
             {
                 return null;
             }


### PR DESCRIPTION
When you have a standard value for a droptree / droplink value, the HasValue will return false when you still have the standard field value. The FieldHasValue will look at the actual value and will return true for a standard value.